### PR TITLE
Use mocked 'and' condition container

### DIFF
--- a/tests/src/RulesAndTest.php
+++ b/tests/src/RulesAndTest.php
@@ -7,12 +7,17 @@
 
 namespace Drupal\rules\Tests;
 
-use Drupal\rules\Plugin\RulesExpression\RulesAnd;
-
 /**
  * Tests the rules AND condition plugin.
  */
 class RulesAndTest extends RulesTestBase {
+
+  /**
+   * A mocked 'and' condition container.
+   *
+   * @var \Drupal\rules\Plugin\RulesExpression\RulesAnd
+   */
+  protected $testRulesAnd;
 
   /**
    * {@inheritdoc}
@@ -33,9 +38,7 @@ class RulesAndTest extends RulesTestBase {
     $this->trueCondition->expects($this->once())
       ->method('execute');
 
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $and = new RulesAnd([], 'test', []);
+    $and = $this->getMockAnd();
     $and->addCondition($this->trueCondition);
     $result = $and->execute();
     $this->assertTrue($result, 'Single condition returns TRUE.');
@@ -45,9 +48,7 @@ class RulesAndTest extends RulesTestBase {
    * Tests an empty AND.
    */
   public function testEmptyAnd() {
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $and = new RulesAnd([], 'test', []);
+    $and = $this->getMockAnd();
     $result = $and->execute();
     $this->assertFalse($result, 'Empty AND returns FALSE.');
   }
@@ -60,9 +61,7 @@ class RulesAndTest extends RulesTestBase {
     $this->trueCondition->expects($this->exactly(2))
       ->method('execute');
 
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $and = new RulesAnd([], 'test', []);
+    $and = $this->getMockAnd();
     $and->addCondition($this->trueCondition);
     $and->addCondition($this->trueCondition);
     $result = $and->execute();
@@ -77,9 +76,7 @@ class RulesAndTest extends RulesTestBase {
     $this->falseCondition->expects($this->once())
       ->method('execute');
 
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $and = new RulesAnd([], 'test', []);
+    $and = $this->getMockAnd();
     $and->addCondition($this->falseCondition);
     $and->addCondition($this->falseCondition);
     $result = $and->execute();

--- a/tests/src/RulesOrTest.php
+++ b/tests/src/RulesOrTest.php
@@ -33,9 +33,7 @@ class RulesOrTest extends RulesTestBase {
     $this->trueCondition->expects($this->once())
       ->method('execute');
 
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $or = new RulesOr([], 'test', []);
+    $or = $this->getMockOr();
     $or->addCondition($this->trueCondition);
     $result = $or->execute();
     $this->assertTrue($result, 'Single condition returns TRUE.');
@@ -45,9 +43,7 @@ class RulesOrTest extends RulesTestBase {
    * Tests an empty OR.
    */
   public function testemptyOr() {
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $or = new RulesOr([], 'test', []);
+    $or = $this->getMockOr();
     $result = $or->execute();
     $this->assertTrue($result, 'Empty OR returns TRUE.');
   }
@@ -60,9 +56,7 @@ class RulesOrTest extends RulesTestBase {
     $this->trueCondition->expects($this->once())
       ->method('execute');
 
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $or = new RulesOr([], 'test', []);
+    $or = $this->getMockOr();
     $or->addCondition($this->trueCondition);
     $or->addCondition($this->trueCondition);
     $result = $or->execute();
@@ -77,9 +71,7 @@ class RulesOrTest extends RulesTestBase {
     $this->falseCondition->expects($this->exactly(2))
       ->method('execute');
 
-    // Create a test rule, we don't care about plugin information in the
-    // constructor.
-    $or = new RulesOr([], 'test', []);
+    $or = $this->getMockOr();
     $or->addCondition($this->falseCondition);
     $or->addCondition($this->falseCondition);
     $result = $or->execute();

--- a/tests/src/RulesTestBase.php
+++ b/tests/src/RulesTestBase.php
@@ -61,4 +61,89 @@ abstract class RulesTestBase extends UnitTestCase {
       ->disableOriginalConstructor()
       ->getMock();
   }
+
+  /**
+   * Creates an 'and' condition container with the basic plugin methods mocked.
+   *
+   * @param array $methods
+   *   (optional) The methods to mock.
+   *
+   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   *   The mocked 'and' condition container.
+   */
+  public function getMockAnd(array $methods = []) {
+    $methods += ['getPluginId', 'getBasePluginId', 'getDerivativeId', 'getPluginDefinition'];
+
+    $rule = $this->getMockBuilder('Drupal\rules\Plugin\RulesExpression\RulesAnd')
+      ->setMethods($methods)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $rule->expects($this->any())
+      ->method('getPluginId')
+      ->will($this->returnValue('rules_and'));
+
+    $rule->expects($this->any())
+      ->method('getBasePluginId')
+      ->will($this->returnValue('rules_and'));
+
+    $rule->expects($this->any())
+      ->method('getDerivativeId')
+      ->will($this->returnValue(NULL));
+
+    $rule->expects($this->any())
+      ->method('getPluginDefinition')
+      ->will($this->returnValue([
+        'type' => '',
+        'id' => 'rules_and',
+        'label' => 'Condition set (AND).',
+        'class' => 'Drupal\rules\Plugin\RulesExpression\RulesAnd',
+        'provider' => 'rules',
+      ]));
+
+    return $rule;
+  }
+
+  /**
+   * Creates an 'or' condition container with the basic plugin methods mocked.
+   *
+   * @param array $methods
+   *   (optional) The methods to mock.
+   *
+   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   *   The mocked 'or' condition container.
+   */
+  public function getMockOr(array $methods = []) {
+    $methods += ['getPluginId', 'getBasePluginId', 'getDerivativeId', 'getPluginDefinition'];
+
+    $rule = $this->getMockBuilder('Drupal\rules\Plugin\RulesExpression\RulesOr')
+      ->setMethods($methods)
+      ->disableOriginalConstructor()
+      ->getMock();
+
+    $rule->expects($this->any())
+      ->method('getPluginId')
+      ->will($this->returnValue('rules_or'));
+
+    $rule->expects($this->any())
+      ->method('getBasePluginId')
+      ->will($this->returnValue('rules_or'));
+
+    $rule->expects($this->any())
+      ->method('getDerivativeId')
+      ->will($this->returnValue(NULL));
+
+    $rule->expects($this->any())
+      ->method('getPluginDefinition')
+      ->will($this->returnValue([
+        'type' => '',
+        'id' => 'rules_or',
+        'label' => 'Condition set (OR).',
+        'class' => 'Drupal\rules\Plugin\RulesExpression\RulesOr',
+        'provider' => 'rules',
+      ]));
+
+    return $rule;
+  }
+
 }


### PR DESCRIPTION
This is better than manually creating one, bypassing the constructor with bogus arguments.
