### PR TITLE
Fix invocation of phpunit in Travis CI test suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,4 +61,4 @@ script:
   # Run the Simpletests for Rules.
   - drush test-run 'Rules, Rules conditions' --uri=http://127.0.0.1:8080
   # Run the PHPUnit tests.
-  - ./vendor/bin/phpunit ../modules/rules
+  - ./vendor/phpunit/phpunit/phpunit ../modules/rules

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This module comes with PHPUnit and Simpletest tests. You need a working Drupal 8
 PHPUnit:
 
     $ cd /path/to/drupal-8/core
-    $ ./vendor/bin/phpunit ../modules/rules
+    $ ./vendor/phpunit/phpunit/phpunit ../modules/rules
 
 Simpletest using drush:
 


### PR DESCRIPTION
After the core phpunit 4.x update it seems that the phpunit tests do not get executed anymore. See https://travis-ci.org/fago/rules/jobs/27966468 for example.

This pull request should fail the Travis check because it contains a PHP syntax error.
