### PR TITLE
2281081 - Port "Data value is empty (data_is_empty)" condition to 8.x

### DIFF
--- a/src/Plugin/Condition/DataIsEmpty.php
+++ b/src/Plugin/Condition/DataIsEmpty.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Plugin\Condition\DataIsEmpty.
+ */
+
+namespace Drupal\rules\Plugin\Condition;
+
+use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\rules\Engine\RulesConditionBase;
+
+/**
+ * Provides a 'Data value is empty' condition.
+ *
+ *  @Condition(
+ *   id = "rules_data_is_empty",
+ *   label = @Translation("Data value is empty"),
+ *   context = {
+ *     "data" = @ContextDefinition("any",
+ *       label = @Translation("Data to check"),
+ *       description = @Translation("The data to be checked to be empty, specified by using a data selector, e.g. 'node:author:name'.")
+ *     )
+ *   }
+ * )
+ *
+ * @todo: Add access callback information from Drupal 7.
+ * @todo: Add group information from Drupal 7.
+ */
+class DataIsEmpty extends RulesConditionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Data value is empty');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    $data = $this->getContextValue('data');
+    if ($data instanceof ComplexDataInterface || $data instanceof ListInterface) {
+      return $data->isEmpty();
+    }
+
+    return empty($data);
+  }
+
+}

--- a/tests/src/Condition/DataIsEmptyTest.php
+++ b/tests/src/Condition/DataIsEmptyTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Tests\Condition\DataIsEmptyTest.
+ */
+
+namespace Drupal\rules\Tests\Condition;
+
+use Drupal\rules\Plugin\Condition\DataIsEmpty;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\rules\Tests\RulesTestBase;
+
+/**
+ * Tests the 'Data is empty' condition.
+ *
+ * @coversDefaultClass \Drupal\rules\Plugin\Condition\DataIsEmpty
+ *
+ * @see \Drupal\rules\Plugin\Condition\DataIsEmpty
+ */
+class DataIsEmptyTest extends RulesTestBase {
+
+  /**
+   * The condition to be tested.
+   *
+   * @var \Drupal\rules\Engine\RulesConditionInterface
+   */
+  protected $condition;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getInfo() {
+    return [
+      'name' => 'Data value is empty condition tests',
+      'description' => 'Tests the data value is empty condition.',
+      'group' => 'Rules conditions',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->condition = new DataIsEmpty([], '', ['context' => [
+      'data' => new ContextDefinition(),
+    ]]);
+    $this->condition->setStringTranslation($this->getMockStringTranslation());
+  }
+
+  /**
+   * Tests the summary.
+   *
+   * @covers ::summary()
+   */
+  public function testSummary() {
+    $this->assertEquals('Data value is empty', $this->condition->summary());
+  }
+
+  /**
+   * Tests evaluating the condition.
+   *
+   * @covers ::evaluate()
+   */
+  public function testConditionEvaluation() {
+    $node = $this->getMock('Drupal\node\NodeInterface');
+    $node->expects($this->at(0))
+      ->method('isEmpty')
+      ->will($this->returnValue(TRUE));
+
+    $node->expects($this->at(1))
+      ->method('isEmpty')
+      ->will($this->returnValue(FALSE));
+
+    // Test a ComplexDataInterface object
+    $this->condition->setContextValue('data', $this->getMockTypedData($node));
+    $this->assertTrue($this->condition->evaluate());
+    $this->assertFalse($this->condition->evaluate());
+
+    // These should all return FALSE.
+    // A non-empty array.
+    $this->condition->setContextValue('data', $this->getMockTypedData([1,2,3]));
+    $this->assertFalse($this->condition->evaluate());
+
+    // An array containing an empty list.
+    $this->condition->setContextValue('data', $this->getMockTypedData([[]]));
+    $this->assertFalse($this->condition->evaluate());
+
+    // An array with a zero-value element.
+    $this->condition->setContextValue('data', $this->getMockTypedData([0]));
+    $this->assertFalse($this->condition->evaluate());
+
+    // A scalar value.
+    $this->condition->setContextValue('data', $this->getMockTypedData(1));
+    $this->assertFalse($this->condition->evaluate());
+
+    $this->condition->setContextValue('data', $this->getMockTypedData('short string'));
+    $this->assertFalse($this->condition->evaluate());
+
+    // These should all return TRUE.
+    // An empty array.
+    $this->condition->setContextValue('data', $this->getMockTypedData([]));
+    $this->assertTrue($this->condition->evaluate());
+
+    // The false/zero/NULL values.
+    $this->condition->setContextValue('data', $this->getMockTypedData(FALSE));
+    $this->assertTrue($this->condition->evaluate());
+
+    $this->condition->setContextValue('data', $this->getMockTypedData(0));
+    $this->assertTrue($this->condition->evaluate());
+
+    $this->condition->setContextValue('data', $this->getMockTypedData(NULL));
+    $this->assertTrue($this->condition->evaluate());
+
+    // An empty string.
+    $this->condition->setContextValue('data', $this->getMockTypedData(''));
+    $this->assertTrue($this->condition->evaluate());
+  }
+
+}


### PR DESCRIPTION
This is basically a copy of https://github.com/fago/rules/pull/66 with added unit test.
Related d.g.o. issue: https://www.drupal.org/node/2281081.
