### PR TITLE
2281079 - Data comparison (data_is) condition implementation.

### DIFF
--- a/src/Plugin/Condition/DataComparison.php
+++ b/src/Plugin/Condition/DataComparison.php
@@ -20,7 +20,7 @@ use Drupal\rules\Engine\RulesConditionBase;
  *       label = @Translation("Data to compare"),
  *       description = @Translation("The data to be checked to be empty, specified by using a data selector, e.g. 'node:uid:entity:name:value'.")
  *     ),
- *     "op" = @ContextDefinition("string",
+ *     "operator" = @ContextDefinition("string",
  *       label = @Translation("Operator"),
  *       description = @Translation("The comparison operator."),
  *       required = FALSE
@@ -50,10 +50,10 @@ class DataComparison extends RulesConditionBase {
    */
   public function evaluate() {
     $data = $this->getContextValue('data');
-    $op = $this->getContext('op')->getContextData() ? $this->getContextValue('op') : '==';
+    $operator = $this->getContext('operator')->getContextData() ? $this->getContextValue('operator') : '==';
     $value = $this->getContextValue('value');
     
-    switch ($op) {
+    switch ($operator) {
       case '<':
         return $data < $value;
 
@@ -66,7 +66,6 @@ class DataComparison extends RulesConditionBase {
       case 'IN':
         return is_array($value) && in_array($data, $value);
 
-      case '==':
       default:
         // In case both values evaluate to FALSE, further differentiate between
         // NULL values and values evaluating to FALSE.

--- a/src/Plugin/Condition/DataComparison.php
+++ b/src/Plugin/Condition/DataComparison.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Plugin\Condition\DataComparison.
+ */
+
+namespace Drupal\rules\Plugin\Condition;
+
+use Drupal\rules\Engine\RulesConditionBase;
+
+/**
+ * Provides a 'Data comparison' condition.
+ *
+ * @Condition(
+ *   id = "rules_data_is",
+ *   label = @Translation("Data comparison"),
+ *   context = {
+ *     "data" = @ContextDefinition("any",
+ *       label = @Translation("Data to compare"),
+ *       description = @Translation("The data to be checked to be empty, specified by using a data selector, e.g. 'node:uid:entity:name:value'.")
+ *     ),
+ *     "op" = @ContextDefinition("string",
+ *       label = @Translation("Operator"),
+ *       description = @Translation("The comparison operator."),
+ *       required = FALSE
+ *     ),
+ *     "value" = @ContextDefinition("any",
+ *        label = @Translation("Data value"),
+ *        description = @Translation("The value to compare the data with.")
+ *     )
+ *   }
+ * )
+ *
+ * @todo: Add access callback information from Drupal 7.
+ * @todo: Add group information from Drupal 7.
+ * @todo: Find a way to port rules_condition_data_is_operator_options() from Drupal 7.
+ */
+class DataComparison extends RulesConditionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Data comparison');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    $data = $this->getContextValue('data');
+    $op = $this->getContext('op')->getContextData() ? $this->getContextValue('op') : '==';
+    $value = $this->getContextValue('value');
+    
+    switch ($op) {
+      case '<':
+        return $this->isLessThan($data, $value);
+
+      case '>':
+        return $this->isGreaterThan($data, $value);
+
+      case 'contains':
+        return $this->contains($data, $value);
+
+      case 'IN':
+        return $this->isOneOf($data, $value);
+
+      case '==':
+      default:
+        return $this->equals($data, $value);
+    }
+  }
+
+  /**
+   * Evaluates the "isLessThan" condition.
+   */
+  protected function isLessThan($data, $value) {
+    return $data < $value;
+  }
+
+  /**
+   * Evaluates the "isGreaterThan" condition.
+   */
+  protected function isGreaterThan($data, $value) {
+    return $data > $value;
+  }
+
+  /**
+   * Evaluates the "contains" condition.
+   *
+   * Note: This is deprecated by the text comparison condition and IN below.
+   */
+  protected function contains($data, $value) {
+    return is_string($data) && strpos($data, $value) !== FALSE || is_array($data) && in_array($value, $data);
+  }
+
+  /**
+   * Evaluates the "IN" condition.
+   */
+  protected function isOneOf($data, $value) {
+    return is_array($value) && in_array($data, $value);
+  }
+
+  /**
+   * Evaluates the "equals" condition.
+   */
+  protected function equals($data, $value) {
+    // In case both values evaluate to FALSE, further differentiate between
+    // NULL values and values evaluating to FALSE.
+    if (!$data && !$value) {
+      return (isset($data) && isset($value)) || (!isset($data) && !isset($value));
+    }
+    return $data == $value;
+  }
+
+}

--- a/src/Plugin/Condition/DataComparison.php
+++ b/src/Plugin/Condition/DataComparison.php
@@ -55,63 +55,26 @@ class DataComparison extends RulesConditionBase {
     
     switch ($op) {
       case '<':
-        return $this->isLessThan($data, $value);
+        return $data < $value;
 
       case '>':
-        return $this->isGreaterThan($data, $value);
+        return $data > $value;
 
       case 'contains':
-        return $this->contains($data, $value);
+        return is_string($data) && strpos($data, $value) !== FALSE || is_array($data) && in_array($value, $data);
 
       case 'IN':
-        return $this->isOneOf($data, $value);
+        return is_array($value) && in_array($data, $value);
 
       case '==':
       default:
-        return $this->equals($data, $value);
+        // In case both values evaluate to FALSE, further differentiate between
+        // NULL values and values evaluating to FALSE.
+        if (!$data && !$value) {
+          return (isset($data) && isset($value)) || (!isset($data) && !isset($value));
+        }
+        return $data == $value;
     }
-  }
-
-  /**
-   * Evaluates the "isLessThan" condition.
-   */
-  protected function isLessThan($data, $value) {
-    return $data < $value;
-  }
-
-  /**
-   * Evaluates the "isGreaterThan" condition.
-   */
-  protected function isGreaterThan($data, $value) {
-    return $data > $value;
-  }
-
-  /**
-   * Evaluates the "contains" condition.
-   *
-   * Note: This is deprecated by the text comparison condition and IN below.
-   */
-  protected function contains($data, $value) {
-    return is_string($data) && strpos($data, $value) !== FALSE || is_array($data) && in_array($value, $data);
-  }
-
-  /**
-   * Evaluates the "IN" condition.
-   */
-  protected function isOneOf($data, $value) {
-    return is_array($value) && in_array($data, $value);
-  }
-
-  /**
-   * Evaluates the "equals" condition.
-   */
-  protected function equals($data, $value) {
-    // In case both values evaluate to FALSE, further differentiate between
-    // NULL values and values evaluating to FALSE.
-    if (!$data && !$value) {
-      return (isset($data) && isset($value)) || (!isset($data) && !isset($value));
-    }
-    return $data == $value;
   }
 
 }

--- a/tests/src/Condition/DataComparisonTest.php
+++ b/tests/src/Condition/DataComparisonTest.php
@@ -46,7 +46,7 @@ class DataComparisonTest extends RulesTestBase {
 
     $this->condition = new DataComparison([], '', ['context' => [
       'data' => new ContextDefinition(),
-      'op' => new ContextDefinition('string', NULL, FALSE),
+      'operator' => new ContextDefinition('string', NULL, FALSE),
       'value' => new ContextDefinition(),
     ]]);
     $this->condition->setStringTranslation($this->getMockStringTranslation());
@@ -85,7 +85,7 @@ class DataComparisonTest extends RulesTestBase {
     // is '==', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Llama'))
-      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('operator', $this->getMockTypedData('=='))
       ->setContextValue('value', $this->getMockTypedData('Llama'));
     $this->assertTrue($this->condition->evaluate());
 
@@ -93,7 +93,7 @@ class DataComparisonTest extends RulesTestBase {
     // operator is '==', FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Kitten'))
-      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('operator', $this->getMockTypedData('=='))
       ->setContextValue('value', $this->getMockTypedData('Llama'));
     $this->assertFalse($this->condition->evaluate());
 
@@ -101,7 +101,7 @@ class DataComparisonTest extends RulesTestBase {
     // is '==', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(FALSE))
-      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('operator', $this->getMockTypedData('=='))
       ->setContextValue('value', $this->getMockTypedData(FALSE));
     $this->assertTrue($this->condition->evaluate());
 
@@ -109,7 +109,7 @@ class DataComparisonTest extends RulesTestBase {
     // and the operator is '==', FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(TRUE))
-      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('operator', $this->getMockTypedData('=='))
       ->setContextValue('value', $this->getMockTypedData(FALSE));
     $this->assertFalse($this->condition->evaluate());
   }
@@ -124,7 +124,7 @@ class DataComparisonTest extends RulesTestBase {
     // is 'CONTAINS', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Big Llama'))
-      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('operator', $this->getMockTypedData('contains'))
       ->setContextValue('value', $this->getMockTypedData('Llama'));
     $this->assertTrue($this->condition->evaluate());
 
@@ -132,7 +132,7 @@ class DataComparisonTest extends RulesTestBase {
     // the operator is 'contains', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Big Kitten'))
-      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('operator', $this->getMockTypedData('contains'))
       ->setContextValue('value', $this->getMockTypedData('Big Kitten'));
     $this->assertTrue($this->condition->evaluate());
 
@@ -140,7 +140,7 @@ class DataComparisonTest extends RulesTestBase {
     // is 'CONTAINS', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(['Llama', 'Kitten']))
-      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('operator', $this->getMockTypedData('contains'))
       ->setContextValue('value', $this->getMockTypedData('Llama'));
     $this->assertTrue($this->condition->evaluate());
 
@@ -148,7 +148,7 @@ class DataComparisonTest extends RulesTestBase {
     // operator is 'CONTAINS', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(['Kitten']))
-      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('operator', $this->getMockTypedData('contains'))
       ->setContextValue('value', $this->getMockTypedData(['Llama']));
     $this->assertFalse($this->condition->evaluate());
   }
@@ -162,7 +162,7 @@ class DataComparisonTest extends RulesTestBase {
     // Test that when the data string is 'IN' the value array, TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Llama'))
-      ->setContextValue('op', $this->getMockTypedData('IN'))
+      ->setContextValue('operator', $this->getMockTypedData('IN'))
       ->setContextValue('value', $this->getMockTypedData(['Llama', 'Kitten']));
     $this->assertTrue($this->condition->evaluate());
 
@@ -170,7 +170,7 @@ class DataComparisonTest extends RulesTestBase {
     // is 'IN', FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(['Llama']))
-      ->setContextValue('op', $this->getMockTypedData('IN'))
+      ->setContextValue('operator', $this->getMockTypedData('IN'))
       ->setContextValue('value', $this->getMockTypedData(['Kitten']));
     $this->assertFalse($this->condition->evaluate());
   }
@@ -185,7 +185,7 @@ class DataComparisonTest extends RulesTestBase {
     // TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(1))
-      ->setContextValue('op', $this->getMockTypedData('<'))
+      ->setContextValue('operator', $this->getMockTypedData('<'))
       ->setContextValue('value', $this->getMockTypedData(2));
     $this->assertTrue($this->condition->evaluate());
 
@@ -193,7 +193,7 @@ class DataComparisonTest extends RulesTestBase {
     // FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(2))
-      ->setContextValue('op', $this->getMockTypedData('<'))
+      ->setContextValue('operator', $this->getMockTypedData('<'))
       ->setContextValue('value', $this->getMockTypedData(1));
     $this->assertFalse($this->condition->evaluate());
   }
@@ -208,7 +208,7 @@ class DataComparisonTest extends RulesTestBase {
     // TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(2))
-      ->setContextValue('op', $this->getMockTypedData('>'))
+      ->setContextValue('operator', $this->getMockTypedData('>'))
       ->setContextValue('value', $this->getMockTypedData(1));
     $this->assertTrue($this->condition->evaluate());
 
@@ -216,7 +216,7 @@ class DataComparisonTest extends RulesTestBase {
     // FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(1))
-      ->setContextValue('op', $this->getMockTypedData('>'))
+      ->setContextValue('operator', $this->getMockTypedData('>'))
       ->setContextValue('value', $this->getMockTypedData(2));
     $this->assertFalse($this->condition->evaluate());
   }

--- a/tests/src/Condition/DataComparisonTest.php
+++ b/tests/src/Condition/DataComparisonTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Tests\Condition\DataComparisonTest.
+ */
+
+namespace Drupal\rules\Tests\Condition;
+
+use Drupal\rules\Plugin\Condition\DataComparison;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\rules\Tests\RulesTestBase;
+
+/**
+ * Tests the 'Data comparison' condition.
+ *
+ * @coversDefaultClass \Drupal\rules\Plugin\Condition\DataComparison
+ *
+ * @see \Drupal\rules\Plugin\Condition\DataComparison
+ */
+class DataComparisonTest extends RulesTestBase {
+
+  /**
+   * The condition to be tested.
+   *
+   * @var \Drupal\rules\Engine\RulesConditionInterface
+   */
+  protected $condition;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getInfo() {
+    return [
+      'name' => 'Data comparison condition tests',
+      'description' => 'Tests that data comparisons are true.',
+      'group' => 'Rules conditions',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->condition = new DataComparison([], '', ['context' => [
+      'data' => new ContextDefinition(),
+      'op' => new ContextDefinition('string', NULL, FALSE),
+      'value' => new ContextDefinition(),
+    ]]);
+    $this->condition->setStringTranslation($this->getMockStringTranslation());
+  }
+
+  /**
+   * Tests the summary.
+   *
+   * @covers ::summary()
+   */
+  public function testSummary() {
+    $this->assertEquals('Data comparison', $this->condition->summary());
+  }
+
+  /**
+   * Tests evaluating the condition with the "equals" operator.
+   */
+  public function testConditionEvaluationOperatorEquals() {
+    // Test that when the data string equals the value string and the operator
+    // is '==', TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData('Llama'))
+      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('value', $this->getMockTypedData('Llama'));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when the data string does not equal the value string and the
+    // operator is '==', FALSE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData('Kitten'))
+      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('value', $this->getMockTypedData('Llama'));
+    $this->assertFalse($this->condition->evaluate());
+
+    // Test that when both data and value are false booleans and the operator
+    // is '==', TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(FALSE))
+      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('value', $this->getMockTypedData(FALSE));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when a boolean data does not equal a boolean value
+    // and the operator is '==', FALSE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(TRUE))
+      ->setContextValue('op', $this->getMockTypedData('=='))
+      ->setContextValue('value', $this->getMockTypedData(FALSE));
+    $this->assertFalse($this->condition->evaluate());
+  }
+
+  /**
+   * Tests evaluating the condition with the "contains" operator.
+   */
+  public function testConditionEvaluationOperatorContains() {
+    // Test that when the data string contains the value string, and the operator
+    // is 'CONTAINS', TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData('Big Llama'))
+      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('value', $this->getMockTypedData('Llama'));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when the data string does not contain the value string, and
+    // the operator is 'contains', TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData('Big Kitten'))
+      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('value', $this->getMockTypedData('Big Kitten'));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when a data array contains the value string, and the operator 
+    // is 'CONTAINS', TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(['Llama', 'Kitten']))
+      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('value', $this->getMockTypedData('Llama'));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when a data array does not contain the value array, and the
+    // operator is 'CONTAINS', TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(['Kitten']))
+      ->setContextValue('op', $this->getMockTypedData('contains'))
+      ->setContextValue('value', $this->getMockTypedData(['Llama']));
+    $this->assertFalse($this->condition->evaluate());
+  }
+
+  /**
+   * Tests evaluating the condition with the "IN" operator.
+   */
+  public function testConditionEvaluationOperatorIN() {
+    // Test that when the data string is 'IN' the value array, TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData('Llama'))
+      ->setContextValue('op', $this->getMockTypedData('IN'))
+      ->setContextValue('value', $this->getMockTypedData(['Llama', 'Kitten']));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when the data array is not in the value array, and the operator
+    // is 'IN', FALSE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(['Llama']))
+      ->setContextValue('op', $this->getMockTypedData('IN'))
+      ->setContextValue('value', $this->getMockTypedData(['Kitten']));
+    $this->assertFalse($this->condition->evaluate());
+  }
+
+  /**
+   * Tests evaluating the condition with the "is less than" operator.
+   */
+  public function testConditionEvaluationOperatorLessThan() {
+    // Test that when data is less than value and operator is '<',
+    // TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(1))
+      ->setContextValue('op', $this->getMockTypedData('<'))
+      ->setContextValue('value', $this->getMockTypedData(2));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when data is greater than value and operator is '<',
+    // FALSE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(2))
+      ->setContextValue('op', $this->getMockTypedData('<'))
+      ->setContextValue('value', $this->getMockTypedData(1));
+    $this->assertFalse($this->condition->evaluate());
+  }
+
+  /**
+   * Tests evaluating the condition with the "is greater than" operator.
+   */
+  public function testConditionEvaluationOperatorGreaterThan() {
+    // Test that when data is greater than value and operator is '>',
+    // TRUE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(2))
+      ->setContextValue('op', $this->getMockTypedData('>'))
+      ->setContextValue('value', $this->getMockTypedData(1));
+    $this->assertTrue($this->condition->evaluate());
+
+    // Test that when data is less than value and operator is '>',
+    // FALSE is returned
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(1))
+      ->setContextValue('op', $this->getMockTypedData('>'))
+      ->setContextValue('value', $this->getMockTypedData(2));
+    $this->assertFalse($this->condition->evaluate());
+  }
+
+}

--- a/tests/src/Condition/DataComparisonTest.php
+++ b/tests/src/Condition/DataComparisonTest.php
@@ -63,10 +63,26 @@ class DataComparisonTest extends RulesTestBase {
 
   /**
    * Tests evaluating the condition with the "equals" operator.
+   *
+   * @covers ::evaluate()
    */
   public function testConditionEvaluationOperatorEquals() {
+    // Test that when a boolean data does not equal a boolean value
+    // and the operator is not set - should fallback to '=='.
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(TRUE))
+      ->setContextValue('value', $this->getMockTypedData(FALSE));
+    $this->assertFalse($this->condition->evaluate());
+
+    // Test that when both data and value are false booleans
+    // and the operator is not set - should fallback to '=='.
+    $this->condition
+      ->setContextValue('data', $this->getMockTypedData(FALSE))
+      ->setContextValue('value', $this->getMockTypedData(FALSE));
+    $this->assertTrue($this->condition->evaluate());
+
     // Test that when the data string equals the value string and the operator
-    // is '==', TRUE is returned
+    // is '==', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Llama'))
       ->setContextValue('op', $this->getMockTypedData('=='))
@@ -74,7 +90,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when the data string does not equal the value string and the
-    // operator is '==', FALSE is returned
+    // operator is '==', FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Kitten'))
       ->setContextValue('op', $this->getMockTypedData('=='))
@@ -82,7 +98,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertFalse($this->condition->evaluate());
 
     // Test that when both data and value are false booleans and the operator
-    // is '==', TRUE is returned
+    // is '==', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(FALSE))
       ->setContextValue('op', $this->getMockTypedData('=='))
@@ -90,7 +106,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when a boolean data does not equal a boolean value
-    // and the operator is '==', FALSE is returned
+    // and the operator is '==', FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(TRUE))
       ->setContextValue('op', $this->getMockTypedData('=='))
@@ -100,10 +116,12 @@ class DataComparisonTest extends RulesTestBase {
 
   /**
    * Tests evaluating the condition with the "contains" operator.
+   *
+   * @covers ::evaluate()
    */
   public function testConditionEvaluationOperatorContains() {
     // Test that when the data string contains the value string, and the operator
-    // is 'CONTAINS', TRUE is returned
+    // is 'CONTAINS', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Big Llama'))
       ->setContextValue('op', $this->getMockTypedData('contains'))
@@ -111,7 +129,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when the data string does not contain the value string, and
-    // the operator is 'contains', TRUE is returned
+    // the operator is 'contains', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Big Kitten'))
       ->setContextValue('op', $this->getMockTypedData('contains'))
@@ -119,7 +137,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when a data array contains the value string, and the operator 
-    // is 'CONTAINS', TRUE is returned
+    // is 'CONTAINS', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(['Llama', 'Kitten']))
       ->setContextValue('op', $this->getMockTypedData('contains'))
@@ -127,7 +145,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when a data array does not contain the value array, and the
-    // operator is 'CONTAINS', TRUE is returned
+    // operator is 'CONTAINS', TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(['Kitten']))
       ->setContextValue('op', $this->getMockTypedData('contains'))
@@ -137,9 +155,11 @@ class DataComparisonTest extends RulesTestBase {
 
   /**
    * Tests evaluating the condition with the "IN" operator.
+   *
+   * @covers ::evaluate()
    */
-  public function testConditionEvaluationOperatorIN() {
-    // Test that when the data string is 'IN' the value array, TRUE is returned
+  public function testConditionEvaluationOperatorIn() {
+    // Test that when the data string is 'IN' the value array, TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData('Llama'))
       ->setContextValue('op', $this->getMockTypedData('IN'))
@@ -147,7 +167,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when the data array is not in the value array, and the operator
-    // is 'IN', FALSE is returned
+    // is 'IN', FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(['Llama']))
       ->setContextValue('op', $this->getMockTypedData('IN'))
@@ -157,10 +177,12 @@ class DataComparisonTest extends RulesTestBase {
 
   /**
    * Tests evaluating the condition with the "is less than" operator.
+   *
+   * @covers ::evaluate()
    */
   public function testConditionEvaluationOperatorLessThan() {
     // Test that when data is less than value and operator is '<',
-    // TRUE is returned
+    // TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(1))
       ->setContextValue('op', $this->getMockTypedData('<'))
@@ -168,7 +190,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when data is greater than value and operator is '<',
-    // FALSE is returned
+    // FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(2))
       ->setContextValue('op', $this->getMockTypedData('<'))
@@ -178,10 +200,12 @@ class DataComparisonTest extends RulesTestBase {
 
   /**
    * Tests evaluating the condition with the "is greater than" operator.
+   *
+   * @covers ::evaluate()
    */
   public function testConditionEvaluationOperatorGreaterThan() {
     // Test that when data is greater than value and operator is '>',
-    // TRUE is returned
+    // TRUE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(2))
       ->setContextValue('op', $this->getMockTypedData('>'))
@@ -189,7 +213,7 @@ class DataComparisonTest extends RulesTestBase {
     $this->assertTrue($this->condition->evaluate());
 
     // Test that when data is less than value and operator is '>',
-    // FALSE is returned
+    // FALSE is returned.
     $this->condition
       ->setContextValue('data', $this->getMockTypedData(1))
       ->setContextValue('op', $this->getMockTypedData('>'))


### PR DESCRIPTION
Initial commit for data comparison condition.

Based on https://github.com/fago/rules/pull/59.
