### PR TITLE
Fix DataProcessorTest after 1825952 

### DIFF
--- a/src/Tests/DataProcessorTest.php
+++ b/src/Tests/DataProcessorTest.php
@@ -43,7 +43,7 @@ class DataProcessorTest extends RulesDrupalTestBase {
     $messages = drupal_set_message();
     // The original value was 1 and the processor adds 1, so the result should
     // be 2.
-    $this->assertEqual($messages['status'][0], '2');
+    $this->assertEqual($messages['status'][0]['message'], '2');
   }
 
 }


### PR DESCRIPTION
Fix after <a href="https://www.drupal.org/node/1825952">Turn on twig autoescape by default.</a>
