### PR TITLE
Initial port of PathAliasDelete with test. Currently works for deleting ...

### DIFF
--- a/src/Plugin/Action/AliasDelete.php
+++ b/src/Plugin/Action/AliasDelete.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Plugin\Action\AliasDelete.
+ */
+
+namespace Drupal\rules\Plugin\Action;
+
+use Drupal\Core\Path\AliasStorageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\rules\Engine\RulesActionBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'Delete any path alias' action.
+ *
+ * @Action(
+ *   id = "rules_path_alias_delete",
+ *   label = @Translation("Delete any path alias"),
+ *   context = {
+ *     "alias" = @ContextDefinition("string",
+ *       label = @Translation("Existing system path alias"),
+ *       description = @Translation("Specifies the existing path alias you wish to delete, for example 'about/team'. Use a relative path and do not add a trailing slash.")
+ *     )
+ *   }
+ * )
+ *
+ * @todo: Add access callback information from Drupal 7.
+ * @todo: Add group information from Drupal 7.
+ */
+class AliasDelete extends RulesActionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The alias storage service.
+   *
+   * @var \Drupal\Core\Path\AliasStorageInterface
+   */
+  protected $aliasStorage;
+
+  /**
+   * Constructs a AliasDelete object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Path\AliasStorageInterface $alias_storage
+   *   The alias storage service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, AliasStorageInterface $alias_storage) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->aliasStorage = $alias_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('path.alias_storage')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Delete any path alias');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    $alias = $this->getContextValue('alias');
+    $this->aliasStorage->delete(['alias' => $alias]);
+  }
+}

--- a/tests/src/Unit/Action/AliasDeleteTest.php
+++ b/tests/src/Unit/Action/AliasDeleteTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\rules\Unit\Action\AliasDeleteTest.
+ */
+
+namespace Drupal\Tests\rules\Unit\Action;
+
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\rules\Plugin\Action\AliasDelete;
+use Drupal\Tests\rules\Unit\RulesUnitTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\rules\Plugin\Action\AliasDelete
+ * @group rules_action
+ */
+class AliasDeleteTest extends RulesUnitTestBase {
+
+  /**
+   * The action to be tested.
+   *
+   * @var \Drupal\rules\Engine\RulesActionInterface
+   */
+  protected $action;
+
+  /**
+   * The mocked alias storage service.
+   *
+   * @var \PHPUnit_Framework_MockObject_MockObject|\Drupal\Core\Path\AliasStorageInterface
+   */
+  protected $aliasStorage;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->aliasStorage = $this->getMock('Drupal\Core\Path\AliasStorageInterface');
+
+    $this->action = new AliasDelete([], '', ['context' => [
+      'alias' => new ContextDefinition('string')
+    ]], $this->aliasStorage);
+
+    $this->action->setStringTranslation($this->getMockStringTranslation());
+    $this->action->setTypedDataManager($this->getMockTypedDataManager());
+  }
+
+  /**
+   * Tests the summary.
+   *
+   * @covers ::summary()
+   */
+  public function testSummary() {
+    $this->assertEquals('Delete any path alias', $this->action->summary());
+  }
+
+  /**
+   * Tests the action execution.
+   *
+   * @covers ::execute()
+   */
+  public function testActionExecution() {
+
+    $alias = 'about/team';
+
+    $this->aliasStorage->expects($this->once())
+      ->method('delete')
+      ->with(['alias' => $alias]);
+
+    $this->action
+      ->setContextValue('alias', $this->getMockTypedData($alias));
+
+    $this->action->execute();
+  }
+}


### PR DESCRIPTION
...a single url alias.

The original D7 function was the create or delete URL alias and thus had two inputs - source and alias. If the source was missing but an alias provided it would delete the alias, and if the alias was missing and a source provided then it would delete aliases associated with that source. 

Now that the create and delete functions are split, the delete only needs one input, i.e. what you want to delete. This initial patch provides the code to delete a single url alias as the class name suggests. 

I believe further discussion is needed to decide how this functionality is going to work in 8, i.e. can we still pass it a source and delete all relevant aliases (how do we check whether it's source or alias?) - can we send it an array of sources and/or aliases, etc. 

So, for the moment, this is a start.
