### PR TITLE
Port Path Alias Delete to D8

### DIFF
--- a/src/Plugin/Action/PathAliasDelete.php
+++ b/src/Plugin/Action/PathAliasDelete.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Plugin\Action\PathAliasDelete.
+ */
+
+namespace Drupal\rules\Plugin\Action;
+
+use Drupal\Core\Path\AliasStorageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\rules\Engine\RulesActionBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'Delete alias for a path' action.
+ *
+ * @Action(
+ *   id = "rules_path_aliases_delete",
+ *   label = @Translation("Delete alias for a path"),
+ *   context = {
+ *     "path" = @ContextDefinition("string",
+ *       label = @Translation("Existing system path"),
+ *       description = @Translation("Specifies the existing path you wish to delete the alias of, for example 'node/1'. Use a relative path and do not add a trailing slash.")
+ *     )
+ *   }
+ * )
+ *
+ * @todo: Add access callback information from Drupal 7.
+ * @todo: Add group information from Drupal 7.
+ */
+class PathAliasDelete extends RulesActionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The alias storage service.
+   *
+   * @var \Drupal\Core\Path\AliasStorageInterface
+   */
+  protected $aliasStorage;
+
+  /**
+   * Constructs a PathAliasDelete object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Path\AliasStorageInterface $alias_storage
+   *   The alias storage service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, AliasStorageInterface $alias_storage) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->aliasStorage = $alias_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('path.alias_storage')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Delete alias for a path');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    $path = $this->getContextValue('path');
+    $this->aliasStorage->delete(['path' => $path]);
+  }
+}

--- a/tests/src/Unit/Action/PathAliasDeleteTest.php
+++ b/tests/src/Unit/Action/PathAliasDeleteTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\rules\Unit\Action\PathAliasDeleteTest.
+ */
+
+namespace Drupal\Tests\rules\Unit\Action;
+
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\rules\Plugin\Action\PathAliasDelete;
+use Drupal\Tests\rules\Unit\RulesUnitTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\rules\Plugin\Action\PathAliasDelete
+ * @group rules_action
+ */
+class PathAliasDeleteTest extends RulesUnitTestBase {
+
+  /**
+   * The action to be tested.
+   *
+   * @var \Drupal\rules\Engine\RulesActionInterface
+   */
+  protected $action;
+
+  /**
+   * The mocked alias storage service.
+   *
+   * @var \PHPUnit_Framework_MockObject_MockObject|\Drupal\Core\Path\AliasStorageInterface
+   */
+  protected $aliasStorage;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->aliasStorage = $this->getMock('Drupal\Core\Path\AliasStorageInterface');
+
+    $this->action = new PathAliasDelete([], '', ['context' => [
+      'path' => new ContextDefinition('string')
+    ]], $this->aliasStorage);
+
+    $this->action->setStringTranslation($this->getMockStringTranslation());
+    $this->action->setTypedDataManager($this->getMockTypedDataManager());
+  }
+
+  /**
+   * Tests the summary.
+   *
+   * @covers ::summary()
+   */
+  public function testSummary() {
+    $this->assertEquals('Delete alias for a path', $this->action->summary());
+  }
+
+  /**
+   * Tests the action execution.
+   *
+   * @covers ::execute()
+   */
+  public function testActionExecution() {
+
+    $path = 'node/1';
+
+    $this->aliasStorage->expects($this->once())
+      ->method('delete')
+      ->with(['path' => $path]);
+
+    $this->action
+      ->setContextValue('path', $this->getMockTypedData($path));
+
+    $this->action->execute();
+  }
+}


### PR DESCRIPTION
Here's an initial stab at the "Delete alias for path". Unsure currently how to deal with multiple values, i.e. if there's more than one alias for the path, couldn't see a relevant function in the AliasManager for this.
