### PR TITLE
Rules list remove item 2317227

### DIFF
--- a/src/Plugin/Action/DataListItemRemove.php
+++ b/src/Plugin/Action/DataListItemRemove.php
@@ -2,10 +2,12 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Plugin\Action\RemoveListItem.
+ * Contains \Drupal\rules\Plugin\Action\DataListItemRemove.
  */
 
 namespace Drupal\rules\Plugin\Action;
+
+use Drupal\rules\Engine\RulesActionBase;
 
 /**
  * Provides a 'Remove item from list' action.
@@ -24,8 +26,11 @@ namespace Drupal\rules\Plugin\Action;
  *    ),
  *   }
  * )
+ *
+ * @todo: Add access callback information from Drupal 7.
+ * @todo: Add group information from Drupal 7.
  */
-class RemoveListItem extends RulesActionBase {
+class DataListItemRemove extends RulesActionBase {
 
   /**
    * {@inheritdoc}
@@ -45,6 +50,6 @@ class RemoveListItem extends RulesActionBase {
       unset($list[$key]);
     }
 
-    $this->setContextValue('list', $list)
+    $this->setContextValue('list', $list);
   }
 }

--- a/src/Plugin/Action/RemoveListItem.php
+++ b/src/Plugin/Action/RemoveListItem.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Plugin\Action\RemoveListItem.
+ */
+
+namespace Drupal\rules\Plugin\Action;
+
+/**
+ * Provides a 'Remove item from list' action.
+ *
+ * @Action(
+ *   id = "rules_list_item_remove",
+ *   label = @Translation("Remove item from list"),
+ *   context = {
+ *    "list" = @ContextDefinition("list",
+ *      label = @Translation("List"),
+ *      description = @Translation("The data list for which an item is to be removed.")
+ *    ),
+ *    "item" = @ContextDefinition("any",
+ *      label = @Translation("Item"),
+ *      description = @Translation("Item to remove.")
+ *    ),
+ *   }
+ * )
+ */
+class RemoveListItem extends RulesActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Remove list item');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    $list = $this->getContextValue('list');
+    $item = $this->getContextValue('item');
+
+    foreach (array_keys($list, $item) as $key) {
+      unset($list[$key]);
+    }
+
+    $this->setContextValue('list', $list)
+  }
+}

--- a/tests/src/Integration/Action/DataListItemRemoveTest.php
+++ b/tests/src/Integration/Action/DataListItemRemoveTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\rules\Integration\Action\DataListItemRemoveTest.
+ */
+
+namespace Drupal\Tests\rules\Integration\Action;
+
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Tests\rules\Integration\RulesIntegrationTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\rules\Plugin\Action\DataListItemRemove
+ * @group rules_actions
+ */
+class DataListItemRemoveTest extends RulesIntegrationTestBase {
+
+  /**
+   * The action to be tested.
+   *
+   * @var \Drupal\rules\Engine\RulesActionInterface
+   */
+  protected $action;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->action = $this->actionManager->createInstance('rules_list_item_remove');
+  }
+
+  /**
+   * Tests the summary.
+   *
+   * @covers ::summary()
+   */
+  public function testSummary() {
+    $this->assertEquals('Remove list item', $this->action->summary());
+  }
+
+  /**
+   * Tests the action execution.
+   *
+   * @covers ::execute()
+   */
+  public function testActionExecution() {
+    $list = array('One', 'Two', 'Three');
+
+    $this->action
+      ->setContextValue('list', $list)
+      ->setContextValue('item', 'Two');
+
+    $this->action->execute();
+
+    // The second item should be removed from the list.
+    $this->assertArrayEquals(array('One', 'Three'), array_values($this->action->getContextValue('list')));
+  }
+}

--- a/tests/src/Integration/Action/DataListItemRemoveTest.php
+++ b/tests/src/Integration/Action/DataListItemRemoveTest.php
@@ -47,7 +47,7 @@ class DataListItemRemoveTest extends RulesIntegrationTestBase {
    * @covers ::execute()
    */
   public function testActionExecution() {
-    $list = array('One', 'Two', 'Three');
+    $list = ['One', 'Two', 'Three'];
 
     $this->action
       ->setContextValue('list', $list)
@@ -56,6 +56,6 @@ class DataListItemRemoveTest extends RulesIntegrationTestBase {
     $this->action->execute();
 
     // The second item should be removed from the list.
-    $this->assertArrayEquals(array('One', 'Three'), array_values($this->action->getContextValue('list')));
+    $this->assertArrayEquals(['One', 'Three'], array_values($this->action->getContextValue('list')));
   }
 }


### PR DESCRIPTION
The following changes were made:
- Plugin class was renamed from RemoveListItem to DataListItemRemove, according to notes listed on https://github.com/fago/rules/pull/102/files;
- A test was added to tests/Integration/Action.
