### PR TITLE
#2281089 Added entity_is_new condition and tests.

### DIFF
--- a/src/Plugin/Condition/EntityIsNew.php
+++ b/src/Plugin/Condition/EntityIsNew.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Plugin\Condition\EntityIsNew.
+ */
+
+namespace Drupal\rules\Plugin\Condition;
+
+use Drupal\rules\Engine\RulesConditionBase;
+
+/**
+ * Provides an 'Entity is new' condition.
+ *
+ * @Condition(
+ *   id = "rules_entity_is_new",
+ *   label = @Translation("Entity is new"),
+ *   category = @Translation("Entity"),
+ *   context = {
+ *     "entity" = @ContextDefinition("entity",
+ *       label = @Translation("Entity"),
+ *       description = @Translation("Specifies the entity for which to evaluate the condition.")
+ *     )
+ *   }
+ * )
+ *
+ * @todo: Add access callback information from Drupal 7?
+ */
+class EntityIsNew extends RulesConditionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return $this->t('Entity is new');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    $provided_entity = $this->getContextValue('entity');
+    return $provided_entity->isNew();
+  }
+}

--- a/tests/src/Integration/Condition/EntityIsNewTest.php
+++ b/tests/src/Integration/Condition/EntityIsNewTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Tests\rules\Integration\Condition\EntityIsNewTest.
+ */
+
+namespace Drupal\Tests\rules\Integration\Condition;
+
+use Drupal\Tests\rules\Integration\RulesEntityIntegrationTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\rules\Plugin\Condition\EntityIsNew
+ * @group rules_conditions
+ */
+class EntityIsNewTest extends RulesEntityIntegrationTestBase {
+
+  /**
+   * The condition to be tested.
+   *
+   * @var \Drupal\rules\Engine\RulesConditionInterface
+   */
+  protected $condition;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->condition = $this->conditionManager->createInstance('rules_entity_is_new');
+  }
+
+  /**
+   * Tests the summary.
+   *
+   * @covers ::summary()
+   */
+  public function testSummary() {
+    $this->assertEquals('Entity is new', $this->condition->summary());
+  }
+
+  /**
+   * Tests evaluating the condition.
+   *
+   * @covers ::evaluate()
+   */
+  public function testConditionEvaluation() {
+    $entity = $this->getMock('Drupal\Core\Entity\EntityInterface');
+    $entity->expects($this->once())
+      ->method('isNew')
+      ->will($this->returnValue(TRUE));
+
+    // Add the test node to our context as the evaluated entity.
+    $this->condition->setContextValue('entity', $entity);
+    $this->assertTrue($this->condition->evaluate());
+  }
+}


### PR DESCRIPTION
This is a replacement for https://github.com/fago/rules/pull/119. I messed up my branches by developing and pushing on 8.x-3.x. This new branch is named according to the conventions and all commits are squashed into one.

https://www.drupal.org/node/2281089
