### PR TITLE
Class and interface naming improvements.

### DIFF
--- a/rules.services.yml
+++ b/rules.services.yml
@@ -1,7 +1,7 @@
 services:
   plugin.manager.rules_expression:
-    class: Drupal\rules\Engine\RulesExpressionPluginManager
+    class: Drupal\rules\Engine\ExpressionPluginManager
     arguments: ['@container.namespaces', '@module_handler']
   plugin.manager.rules_data_processor:
-    class: Drupal\rules\Engine\RulesDataProcessorManager
+    class: Drupal\rules\Context\DataProcessorManager
     arguments: ['@container.namespaces', '@module_handler']

--- a/src/Context/ContextConfig.php
+++ b/src/Context/ContextConfig.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Context\ContextConfig
+ * Contains \Drupal\rules\Context\ContextConfig.
  */
 
 namespace Drupal\rules\Context;
@@ -20,9 +20,9 @@ class ContextConfig {
    * @var array
    */
   protected $config = [
-    'context' => [],
-    'context_map' => [],
-    'context_process' => [],
+    'context_values' => [],
+    'context_mapping' => [],
+    'context_processors' => [],
   ];
 
   /**
@@ -64,10 +64,11 @@ class ContextConfig {
    * @return $this
    */
   public function map($context_name, $selector) {
-    if (isset($this->config['context'][$context_name])) {
+    if (isset($this->config['context_values'][$context_name])) {
       throw new \LogicException("Cannot map a context value and pre-define it at the same time.");
     }
-    $this->config['context_map'][$context_name] = $selector;
+    $this->config['context_mapping'][$context_name] = $selector;
+    return $this;
   }
 
   /**
@@ -86,11 +87,12 @@ class ContextConfig {
    *
    * @return $this
    */
-  public function setContextValue($context_name, $value) {
-    if (isset($this->config['context_map'][$context_name])) {
+  public function setValue($context_name, $value) {
+    if (isset($this->config['context_mapping'][$context_name])) {
       throw new \LogicException("Cannot map a context value and pre-define it at the same time.");
     }
-    $this->config['context'][$context_name] = $value;
+    $this->config['context_values'][$context_name] = $value;
+    return $this;
   }
 
   /**
@@ -108,6 +110,7 @@ class ContextConfig {
    */
   public function setConfigKey($key, $value) {
     $this->config[$key] = $value;
+    return $this;
   }
 
   /**
@@ -123,7 +126,8 @@ class ContextConfig {
    * @return $this
    */
   public function process($context_name, $plugin_id, $options = []) {
-    $this->config['context_process'][$context_name][$plugin_id] = $options;
+    $this->config['context_processors'][$context_name][$plugin_id] = $options;
+    return $this;
   }
 
   /**
@@ -147,7 +151,7 @@ class ContextConfig {
    *   The config array, with the following keys set:
    *   - context_map: An array of data selectors, keyed by context name.
    *   - context An array of context values, keyed by context.
-   *   - context_process: An array of data processor config, keyed by context
+   *   - context_processors: An array of data processor config, keyed by context
    *     name and process plugin id.
    *   - Any other other config keys that have been set.
    */

--- a/src/Context/ContextConfig.php
+++ b/src/Context/ContextConfig.php
@@ -23,6 +23,7 @@ class ContextConfig {
     'context_values' => [],
     'context_mapping' => [],
     'context_processors' => [],
+    'provides_mapping' => [],
   ];
 
   /**
@@ -96,6 +97,21 @@ class ContextConfig {
   }
 
   /**
+   * Maps the name of a provided context.
+   *
+   * @param string $provided_context_name
+   *   The name of the provided context.
+   * @param string $context_name
+   *   The context name under which the provided context should be registered.
+   *
+   * @return $this
+   */
+  public function provideAs($provided_context_name, $context_name) {
+    $this->config['provides_mapping'][$provided_context_name] = $context_name;
+    return $this;
+  }
+
+  /**
    * Sets an arbitrary configuration value under the given key.
    *
    * This may be used for setting any configuration options that are not making
@@ -153,6 +169,8 @@ class ContextConfig {
    *   - context An array of context values, keyed by context.
    *   - context_processors: An array of data processor config, keyed by context
    *     name and process plugin id.
+   *   - provides_mapping: An array of context names to use for provided
+   *     context, keyed by provided context name.
    *   - Any other other config keys that have been set.
    */
   public function toArray() {

--- a/src/Context/ContextConfig.php
+++ b/src/Context/ContextConfig.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Context\ContextConfig
+ */
+
+namespace Drupal\rules\Context;
+
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+
+/**
+ * Class for value objects helping with context configuration.
+ */
+class ContextConfig {
+
+  /**
+   * The config array.
+   *
+   * @var array
+   */
+  protected $config = [
+    'context' => [],
+    'context_map' => [],
+    'context_process' => [],
+  ];
+
+  /**
+   * Creates a context config object.
+   *
+   * @param array $values
+   *   (optional) Some initial values to set. In the same format as returned
+   *   from static::toArray().
+   *
+   * @return static
+   */
+  public static function create(array $values = []) {
+    return new static($values);
+  }
+
+  /**
+   * Constructs the object.
+   *
+   * @param array $values
+   *   Some initial values to set. In the same format as returned from
+   *   static::toArray().
+   */
+  protected function __construct(array $values) {
+    $this->config = $values + $this->config;
+  }
+
+  /**
+   * Maps the data specified by the selector to the given context.
+   *
+   * @param string $context_name
+   *   The name of the context.
+   * @param string $selector
+   *   A valid data selector; e.g., "node:uid:target_id".
+   *
+   * @throws \LogicException
+   *   Thrown if a context value and map are set for a given context at the same
+   *   time.
+   *
+   * @return $this
+   */
+  public function map($context_name, $selector) {
+    if (isset($this->config['context'][$context_name])) {
+      throw new \LogicException("Cannot map a context value and pre-define it at the same time.");
+    }
+    $this->config['context_map'][$context_name] = $selector;
+  }
+
+  /**
+   * Sets a pre-defined value for the given context.
+   *
+   * @param string $context_name
+   *   The name of the context.
+   * @param mixed $value
+   *   The value to set for the context. The value must he a valid value for the
+   *   context's data type, unless a data processor takes care of processing it
+   *   to a valid value.
+   *
+   * @throws \LogicException
+   *   Thrown if a context value and map are set for a given context at the same
+   *   time.
+   *
+   * @return $this
+   */
+  public function setContextValue($context_name, $value) {
+    if (isset($this->config['context_map'][$context_name])) {
+      throw new \LogicException("Cannot map a context value and pre-define it at the same time.");
+    }
+    $this->config['context'][$context_name] = $value;
+  }
+
+  /**
+   * Sets an arbitrary configuration value under the given key.
+   *
+   * This may be used for setting any configuration options that are not making
+   * use of the context system.
+   *
+   * @param string $key
+   *   The config key to set.
+   * @param mixed $value
+   *   The value to set for the config key.
+   *
+   * @return $this
+   */
+  public function setConfigKey($key, $value) {
+    $this->config[$key] = $value;
+  }
+
+  /**
+   * Configures a data processor for the given context.
+   *
+   * @param string $context_name
+   *   The name of the context.
+   * @param string $plugin_id
+   *   The id of the data processor plugin to use.
+   * @param array $options
+   *   (optional) An array of plugin configuration, as used by the plugin.
+   *
+   * @return $this
+   */
+  public function process($context_name, $plugin_id, $options = []) {
+    $this->config['context_process'][$context_name][$plugin_id] = $options;
+  }
+
+  /**
+   * Negates the result of the plugin (or not).
+   *
+   * Only applicable to condition plugins.
+   *
+   * @param bool $bool
+   *   Whether to negate the result.
+   *
+   * @return $this
+   */
+  public function negateResult($bool = TRUE) {
+    return $this->setConfigKey('negate', $bool);
+  }
+
+  /**
+   * Exports the configuration to an array.
+   *
+   * @return array
+   *   The config array, with the following keys set:
+   *   - context_map: An array of data selectors, keyed by context name.
+   *   - context An array of context values, keyed by context.
+   *   - context_process: An array of data processor config, keyed by context
+   *     name and process plugin id.
+   *   - Any other other config keys that have been set.
+   */
+  public function toArray() {
+    return $this->config;
+  }
+
+  /**
+   * Checks the config for the given plugin.
+   *
+   * @param \Drupal\Core\Plugin\ContextAwarePluginInterface $plugin
+   *   An instance of the plugin for which the config has been created.
+   *
+   * @todo: Implement.
+   */
+  public function checkConfig(ContextAwarePluginInterface $plugin) {
+    // @todo.
+  }
+
+}

--- a/src/Context/DataProcessorInterface.php
+++ b/src/Context/DataProcessorInterface.php
@@ -2,15 +2,15 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesDataProcessorInterface.
+ * Contains \Drupal\rules\Context\DataProcessorInterface.
  */
 
-namespace Drupal\rules\Engine;
+namespace Drupal\rules\Context;
 
 /**
  * Interface for Rules data processor plugins.
  */
-interface RulesDataProcessorInterface {
+interface DataProcessorInterface {
 
   /**
    * Process the given value.

--- a/src/Context/DataProcessorManager.php
+++ b/src/Context/DataProcessorManager.php
@@ -2,10 +2,10 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesDataProcessorManager.
+ * Contains \Drupal\rules\Context\DataProcessorManager.
  */
 
-namespace Drupal\rules\Engine;
+namespace Drupal\rules\Context;
 
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
@@ -15,14 +15,14 @@ use Drupal\Core\Plugin\DefaultPluginManager;
  *
  * @see \Drupal\rules\Engine\RulesDataProcessorInterface
  */
-class RulesDataProcessorManager extends DefaultPluginManager {
+class DataProcessorManager extends DefaultPluginManager {
 
   /**
    * {@inheritdoc}
    */
   public function __construct(\Traversable $namespaces, ModuleHandlerInterface $module_handler, $plugin_definition_annotation_name = 'Drupal\rules\Annotation\RulesDataProcessor') {
     $this->alterInfo('rules_data_processor');
-    parent::__construct('Plugin/RulesDataProcessor', $namespaces, $module_handler, 'Drupal\rules\Engine\RulesDataProcessorInterface', $plugin_definition_annotation_name);
+    parent::__construct('Plugin/RulesDataProcessor', $namespaces, $module_handler, 'Drupal\rules\Context\DataProcessorInterface', $plugin_definition_annotation_name);
   }
 
 }

--- a/src/Context/RulesContextTrait.php
+++ b/src/Context/RulesContextTrait.php
@@ -99,8 +99,8 @@ trait RulesContextTrait {
         $plugin->setContextValue($name, $context_value);
       }
       // Check if a data selector is configured that maps to the state.
-      elseif (isset($this->configuration['context_mapping'][$name . ':select'])) {
-        $typed_data = $state->applyDataSelector($this->configuration['context_mapping'][$name . ':select']);
+      elseif (isset($this->configuration['context_mapping'][$name])) {
+        $typed_data = $state->applyDataSelector($this->configuration['context_mapping'][$name]);
         $plugin->setContextValue($name, $typed_data);
       }
       elseif ($definition->isRequired()) {
@@ -141,8 +141,8 @@ trait RulesContextTrait {
    *   The plugin to process the context data on.
    */
   protected function processData(ContextAwarePluginInterface $plugin) {
-    if (isset($this->configuration['processor_mapping'])) {
-      foreach ($this->configuration['processor_mapping'] as $name => $settings) {
+    if (isset($this->configuration['context_processors'])) {
+      foreach ($this->configuration['context_processors'] as $name => $settings) {
         $data_processor = $this->processorManager->createInstance($settings['plugin'], $settings['configuration']);
         $new_value = $data_processor->process($plugin->getContextValue($name));
         $plugin->setContextValue($name, $new_value);

--- a/src/Context/RulesContextTrait.php
+++ b/src/Context/RulesContextTrait.php
@@ -29,7 +29,7 @@ trait RulesContextTrait {
   /**
    * The data processor plugin manager used to process context variables.
    *
-   * @var \Drupal\rules\Engine\RulesDataProcessorManager
+   * @var \Drupal\rules\Context\DataProcessorManager
    */
   protected $processorManager;
 

--- a/src/Engine/ActionExpressionContainerInterface.php
+++ b/src/Engine/ActionExpressionContainerInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesActionContainerInterface.
+ * Contains \Drupal\rules\Engine\ActionExpressionContainerInterface.
  */
 
 namespace Drupal\rules\Engine;
@@ -12,7 +12,7 @@ use Drupal\rules\Context\ContextConfig;
 /**
  * Contains action expressions.
  */
-interface RulesActionContainerInterface extends RulesExpressionActionInterface, RulesExpressionContainerInterface {
+interface ActionExpressionContainerInterface extends ActionExpressionInterface, ExpressionContainerInterface {
 
   /**
    * Creates an action expression and adds it to the container.

--- a/src/Engine/ActionExpressionInterface.php
+++ b/src/Engine/ActionExpressionInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesExpressionActionInterface.
+ * Contains \Drupal\rules\Engine\ActionExpressionInterface.
  */
 
 namespace Drupal\rules\Engine;
@@ -12,6 +12,6 @@ use Drupal\rules\Core\RulesActionInterface;
 /**
  * Defines the interface for Rules expressions that can be used as actions.
  */
-interface RulesExpressionActionInterface extends RulesActionInterface, RulesExpressionInterface {
+interface ActionExpressionInterface extends RulesActionInterface, ExpressionInterface {
 
 }

--- a/src/Engine/ConditionExpressionContainer.php
+++ b/src/Engine/ConditionExpressionContainer.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesConditionContainer.
+ * Contains \Drupal\rules\Engine\ConditionExpressionContainer.
  */
 
 namespace Drupal\rules\Engine;
@@ -11,13 +11,12 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\rules\Core\RulesConditionBase;
 use Drupal\rules\Context\ContextConfig;
 use Drupal\rules\Exception\InvalidExpressionException;
-use Drupal\rules\Engine\RulesExpressionPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Container for conditions.
  */
-abstract class RulesConditionContainer extends RulesConditionBase implements RulesConditionContainerInterface, ContainerFactoryPluginInterface {
+abstract class ConditionExpressionContainer extends RulesConditionBase implements ConditionExpressionContainerInterface, ContainerFactoryPluginInterface {
 
   use RulesExpressionTrait;
 
@@ -37,10 +36,10 @@ abstract class RulesConditionContainer extends RulesConditionBase implements Rul
    *   The plugin_id for the plugin instance.
    * @param array $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\rules\Engine\RulesExpressionPluginManager $expression_manager
+   * @param \Drupal\rules\Engine\ExpressionPluginManager $expression_manager
    *   The rules expression plugin manager.
    */
-  public function __construct(array $configuration, $plugin_id, array $plugin_definition, RulesExpressionPluginManager $expression_manager) {
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, ExpressionPluginManager $expression_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->expressionManager = $expression_manager;
 
@@ -66,8 +65,8 @@ abstract class RulesConditionContainer extends RulesConditionBase implements Rul
   /**
    * {@inheritdoc}
    */
-  public function addExpressionObject(RulesExpressionInterface $expression) {
-    if (!$expression instanceof RulesExpressionConditionInterface) {
+  public function addExpressionObject(ExpressionInterface $expression) {
+    if (!$expression instanceof ConditionExpressionInterface) {
       throw new InvalidExpressionException();
     }
     $this->conditions[] = $expression;

--- a/src/Engine/ConditionExpressionContainerInterface.php
+++ b/src/Engine/ConditionExpressionContainerInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesConditionContainerInterface.
+ * Contains \Drupal\rules\Engine\ConditionExpressionContainerInterface.
  */
 
 namespace Drupal\rules\Engine;
@@ -12,7 +12,7 @@ use Drupal\rules\Context\ContextConfig;
 /**
  * Contains condition expressions.
  */
-interface RulesConditionContainerInterface extends RulesExpressionConditionInterface, RulesExpressionContainerInterface {
+interface ConditionExpressionContainerInterface extends ConditionExpressionInterface, ExpressionContainerInterface {
 
   /**
    * Creates a condition expression and adds it to the container.

--- a/src/Engine/ConditionExpressionInterface.php
+++ b/src/Engine/ConditionExpressionInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesExpressionConditionInterface.
+ * Contains \Drupal\rules\Engine\ConditionExpressionInterface.
  */
 
 namespace Drupal\rules\Engine;
@@ -12,6 +12,6 @@ use Drupal\rules\Core\RulesConditionInterface;
 /**
  * Defines the interface for Rules expressions that can be used as conditions.
  */
-interface RulesExpressionConditionInterface extends RulesConditionInterface, RulesExpressionInterface {
+interface ConditionExpressionInterface extends RulesConditionInterface, ExpressionInterface {
 
 }

--- a/src/Engine/ExpressionContainerInterface.php
+++ b/src/Engine/ExpressionContainerInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesExpressionContainerInterface.
+ * Contains \Drupal\rules\Engine\ExpressionContainerInterface.
  */
 
 namespace Drupal\rules\Engine;
@@ -12,10 +12,10 @@ use Drupal\rules\Context\ContextConfig;
  * Defines a common interface for expressions containing other expressions.
  *
  * Usually expression containers also implement the
- * RulesActionContainerInterface or RulesConditionContainerInterface in order
+ * ActionExpressionContainerInterface or ConditionExpressionContainerInterface in order
  * to denote whether it contains action or condition expressions.
  */
-interface RulesExpressionContainerInterface extends RulesExpressionInterface {
+interface ExpressionContainerInterface extends ExpressionInterface {
 
   /**
    * Creates and adds an expression.
@@ -36,7 +36,7 @@ interface RulesExpressionContainerInterface extends RulesExpressionInterface {
   /**
    * Adds an expression object.
    *
-   * @param \Drupal\rules\Engine\RulesExpressionInterface $expression
+   * @param \Drupal\rules\Engine\ExpressionInterface $expression
    *   The expression object.
    *
    * @throws \Drupal\rules\Exception\InvalidExpressionException
@@ -45,6 +45,6 @@ interface RulesExpressionContainerInterface extends RulesExpressionInterface {
    *
    * @return $this
    */
-  public function addExpressionObject(RulesExpressionInterface $expression);
+  public function addExpressionObject(ExpressionInterface $expression);
 
 }

--- a/src/Engine/ExpressionInterface.php
+++ b/src/Engine/ExpressionInterface.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Engine\RulesExpressionInterface.
+ * Contains \Drupal\rules\Engine\ExpressionInterface.
  */
 
 namespace Drupal\rules\Engine;
@@ -16,7 +16,7 @@ use Drupal\Core\Executable\ExecutableInterface;
  *
  * @see \Drupal\rules\Plugin\RulesExpressionPluginManager
  */
-interface RulesExpressionInterface extends ExecutableInterface, ContextAwarePluginInterface, ConfigurablePluginInterface {
+interface ExpressionInterface extends ExecutableInterface, ContextAwarePluginInterface, ConfigurablePluginInterface {
 
   /**
    * Execute the expression with a given Rules state.

--- a/src/Engine/ExpressionPluginManager.php
+++ b/src/Engine/ExpressionPluginManager.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Plugin\RulesExpressionPluginManager.
+ * Contains \Drupal\rules\Plugin\ExpressionPluginManager.
  */
 
 namespace Drupal\rules\Engine;
@@ -13,9 +13,9 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 /**
  * Plugin manager for all Rules expressions.
  *
- * @see \Drupal\rules\Engine\RulesExpressionInterface
+ * @see \Drupal\rules\Engine\ExpressionInterface
  */
-class RulesExpressionPluginManager extends DefaultPluginManager {
+class ExpressionPluginManager extends DefaultPluginManager {
 
   /**
    * A map from class names to plugin ids.
@@ -29,7 +29,7 @@ class RulesExpressionPluginManager extends DefaultPluginManager {
    */
   public function __construct(\Traversable $namespaces, ModuleHandlerInterface $module_handler, $plugin_definition_annotation_name = 'Drupal\rules\Annotation\RulesExpression') {
     $this->alterInfo('rules_expression');
-    parent::__construct('Plugin/RulesExpression', $namespaces, $module_handler, 'Drupal\rules\Engine\RulesExpressionInterface', $plugin_definition_annotation_name);
+    parent::__construct('Plugin/RulesExpression', $namespaces, $module_handler, 'Drupal\rules\Engine\ExpressionInterface', $plugin_definition_annotation_name);
   }
 
   /**
@@ -78,7 +78,7 @@ class RulesExpressionPluginManager extends DefaultPluginManager {
   /**
    * Creates a new 'and' condition container.
    *
-   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @return \Drupal\rules\Engine\ConditionExpressionContainerInterface
    *   The created 'and' condition container.
    */
   public function createAnd() {
@@ -88,7 +88,7 @@ class RulesExpressionPluginManager extends DefaultPluginManager {
   /**
    * Creates a new 'or' condition container.
    *
-   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @return \Drupal\rules\Engine\ConditionExpressionContainerInterface
    *   The created 'or' condition container.
    */
   public function createOr() {

--- a/src/Engine/RulesActionContainerInterface.php
+++ b/src/Engine/RulesActionContainerInterface.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\rules\Engine;
 
+use Drupal\rules\Context\ContextConfig;
+
 /**
  * Contains action expressions.
  */
@@ -16,12 +18,12 @@ interface RulesActionContainerInterface extends RulesExpressionActionInterface, 
    * Creates an action expression and adds it to the container.
    *
    * @param string $action_id
-   *   The action plugin id
-   * @param array $configuration
+   *   The action plugin id.
+   * @param \Drupal\rules\Context\ContextConfig $config
    *   (optional) The configuration for the specified plugin.
    *
    * @return $this
    */
-  public function addAction($action_id, $configuration = NULL);
+  public function addAction($action_id, ContextConfig $config = NULL);
 
 }

--- a/src/Engine/RulesConditionContainer.php
+++ b/src/Engine/RulesConditionContainer.php
@@ -77,23 +77,20 @@ abstract class RulesConditionContainer extends RulesConditionBase implements Rul
   /**
    * {@inheritdoc}
    */
-  public function addExpression($plugin_id, $configuration = NULL) {
+  public function addExpression($plugin_id, ContextConfig $config = NULL) {
     return $this->addExpressionObject(
-      $this->expressionManager->createInstance($plugin_id, $configuration ?: [])
+      $this->expressionManager->createInstance($plugin_id, $config ? $config->toArray() : [])
     );
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addCondition($condition_id, $configuration = NULL) {
-    if ($configuration instanceof ContextConfig) {
-      $configuration = $configuration->toArray();
-    }
+  public function addCondition($condition_id, ContextConfig $config = NULL) {
     return $this->addExpressionObject(
       $this->expressionManager
         ->createCondition($condition_id)
-        ->setConfiguration($configuration ?: [])
+        ->setConfiguration($config ? $config->toArray() : [])
     );
   }
 

--- a/src/Engine/RulesConditionContainer.php
+++ b/src/Engine/RulesConditionContainer.php
@@ -9,6 +9,7 @@ namespace Drupal\rules\Engine;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\rules\Core\RulesConditionBase;
+use Drupal\rules\Context\ContextConfig;
 use Drupal\rules\Exception\InvalidExpressionException;
 use Drupal\rules\Engine\RulesExpressionPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -86,6 +87,9 @@ abstract class RulesConditionContainer extends RulesConditionBase implements Rul
    * {@inheritdoc}
    */
   public function addCondition($condition_id, $configuration = NULL) {
+    if ($configuration instanceof ContextConfig) {
+      $configuration = $configuration->toArray();
+    }
     return $this->addExpressionObject(
       $this->expressionManager
         ->createCondition($condition_id)

--- a/src/Engine/RulesConditionContainerInterface.php
+++ b/src/Engine/RulesConditionContainerInterface.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\rules\Engine;
 
+use Drupal\rules\Context\ContextConfig;
+
 /**
  * Contains condition expressions.
  */
@@ -17,11 +19,11 @@ interface RulesConditionContainerInterface extends RulesExpressionConditionInter
    *
    * @param string $condition_id
    *   The condition plugin id.
-   * @param array $configuration
+   * @param \Drupal\rules\Context\ContextConfig $config
    *   (optional) The configuration for the specified plugin.
    *
    * @return \Drupal\rules\Core\RulesConditionInterface
    *   The created condition.
    */
-  public function addCondition($condition_id, $configuration = NULL);
+  public function addCondition($condition_id, ContextConfig $config = NULL);
 }

--- a/src/Engine/RulesExpressionContainerInterface.php
+++ b/src/Engine/RulesExpressionContainerInterface.php
@@ -6,6 +6,7 @@
  */
 
 namespace Drupal\rules\Engine;
+use Drupal\rules\Context\ContextConfig;
 
 /**
  * Defines a common interface for expressions containing other expressions.
@@ -21,7 +22,7 @@ interface RulesExpressionContainerInterface extends RulesExpressionInterface {
    *
    * @param string $plugin_id
    *   The id of the expression plugin to add.
-   * @param array $configuration
+   * @param \Drupal\rules\Context\ContextConfig $config
    *   (optional) The configuration for the specified plugin.
    *
    * @throws \Drupal\rules\Exception\InvalidExpressionException
@@ -30,7 +31,7 @@ interface RulesExpressionContainerInterface extends RulesExpressionInterface {
    *
    * @return $this
    */
-  public function addExpression($plugin_id, $configuration = NULL);
+  public function addExpression($plugin_id, ContextConfig $config = NULL);
 
   /**
    * Adds an expression object.

--- a/src/Engine/RulesExpressionTrait.php
+++ b/src/Engine/RulesExpressionTrait.php
@@ -13,7 +13,7 @@ namespace Drupal\rules\Engine;
 trait RulesExpressionTrait {
 
   /**
-   * @var \Drupal\rules\Engine\RulesExpressionPluginManager
+   * @var \Drupal\rules\Engine\ExpressionPluginManager
    */
   protected $expressionManager;
 

--- a/src/Entity/RulesComponent.php
+++ b/src/Entity/RulesComponent.php
@@ -81,7 +81,7 @@ class RulesComponent extends ConfigEntityBase {
   /**
    * Stores a reference to the executable expression version of this component.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionInterface
+   * @var \Drupal\rules\Engine\ExpressionInterface
    */
   protected $expression;
 
@@ -95,7 +95,7 @@ class RulesComponent extends ConfigEntityBase {
   /**
    * Gets a Rules expression instance for this Rules component.
    *
-   * @return \Drupal\rules\Engine\RulesExpressionInterface
+   * @return \Drupal\rules\Engine\ExpressionInterface
    *   A Rules expression instance.
    */
   public function getExpression() {
@@ -113,7 +113,7 @@ class RulesComponent extends ConfigEntityBase {
    * @todo Actually we should use dependency injection here, but is that even
    *   possible with config entities? How?
    *
-   * @return \Drupal\rules\Engine\RulesExpressionPluginManager
+   * @return \Drupal\rules\Engine\ExpressionPluginManager
    *   The Rules expression manager.
    */
   protected function getExpressionManager() {

--- a/src/Plugin/RulesDataProcessor/NumericOffset.php
+++ b/src/Plugin/RulesDataProcessor/NumericOffset.php
@@ -8,7 +8,7 @@
 namespace Drupal\rules\Plugin\RulesDataProcessor;
 
 use Drupal\Core\Plugin\PluginBase;
-use Drupal\rules\Engine\RulesDataProcessorInterface;
+use Drupal\rules\Context\DataProcessorInterface;
 
 /**
  * A data processor for applying numerical offsets.
@@ -21,7 +21,7 @@ use Drupal\rules\Engine\RulesDataProcessorInterface;
  *   label = @Translation("Apply numeric offset")
  * )
  */
-class NumericOffset extends PluginBase implements RulesDataProcessorInterface {
+class NumericOffset extends PluginBase implements DataProcessorInterface {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/RulesExpression/ActionSet.php
+++ b/src/Plugin/RulesExpression/ActionSet.php
@@ -9,6 +9,7 @@ namespace Drupal\rules\Plugin\RulesExpression;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\rules\Core\RulesActionBase;
+use Drupal\rules\Context\ContextConfig;
 use Drupal\rules\Engine\RulesActionContainerInterface;
 use Drupal\rules\Engine\RulesExpressionActionInterface;
 use Drupal\rules\Engine\RulesExpressionInterface;
@@ -86,20 +87,20 @@ class ActionSet extends RulesActionBase implements RulesActionContainerInterface
   /**
    * {@inheritdoc}
    */
-  public function addExpression($plugin_id, $configuration = NULL) {
+  public function addExpression($plugin_id, ContextConfig $config = NULL) {
     return $this->addExpressionObject(
-      $this->expressionManager->createInstance($plugin_id, $configuration ?: [])
+      $this->expressionManager->createInstance($plugin_id, $config ? $config->toArray() : [])
     );
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addAction($action_id, $configuration = NULL) {
+  public function addAction($action_id, ContextConfig $config = NULL) {
     return $this->addExpressionObject(
       $this->expressionManager
         ->createAction($action_id)
-        ->setConfiguration($configuration ?: [])
+        ->setConfiguration($config ? $config->toArray() : [])
     );
   }
 

--- a/src/Plugin/RulesExpression/ActionSet.php
+++ b/src/Plugin/RulesExpression/ActionSet.php
@@ -10,13 +10,13 @@ namespace Drupal\rules\Plugin\RulesExpression;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\rules\Core\RulesActionBase;
 use Drupal\rules\Context\ContextConfig;
-use Drupal\rules\Engine\RulesActionContainerInterface;
-use Drupal\rules\Engine\RulesExpressionActionInterface;
-use Drupal\rules\Engine\RulesExpressionInterface;
+use Drupal\rules\Engine\ActionExpressionContainerInterface;
+use Drupal\rules\Engine\ActionExpressionInterface;
+use Drupal\rules\Engine\ExpressionInterface;
 use Drupal\rules\Engine\RulesExpressionTrait;
 use Drupal\rules\Engine\RulesState;
 use Drupal\rules\Exception\InvalidExpressionException;
-use Drupal\rules\Engine\RulesExpressionPluginManager;
+use Drupal\rules\Engine\ExpressionPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -27,14 +27,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   label = @Translation("Action set")
  * )
  */
-class ActionSet extends RulesActionBase implements RulesActionContainerInterface, ContainerFactoryPluginInterface {
+class ActionSet extends RulesActionBase implements ActionExpressionContainerInterface, ContainerFactoryPluginInterface {
 
   use RulesExpressionTrait;
 
   /**
    * List of actions that will be executed.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionActionInterface[]
+   * @var \Drupal\rules\Engine\ActionExpressionInterface[]
    */
   protected $actions = [];
 
@@ -47,10 +47,10 @@ class ActionSet extends RulesActionBase implements RulesActionContainerInterface
    *   The plugin_id for the plugin instance.
    * @param array $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\rules\Engine\RulesExpressionPluginManager $expression_manager
+   * @param \Drupal\rules\Engine\ExpressionPluginManager $expression_manager
    *   The rules expression plugin manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RulesExpressionPluginManager $expression_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ExpressionPluginManager $expression_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->expressionManager = $expression_manager;
 
@@ -76,8 +76,8 @@ class ActionSet extends RulesActionBase implements RulesActionContainerInterface
   /**
    * {@inheritdoc}
    */
-  public function addExpressionObject(RulesExpressionInterface $expression) {
-    if (!$expression instanceof RulesExpressionActionInterface) {
+  public function addExpressionObject(ExpressionInterface $expression) {
+    if (!$expression instanceof ActionExpressionInterface) {
       throw new InvalidExpressionException();
     }
     $this->actions[] = $expression;

--- a/src/Plugin/RulesExpression/Rule.php
+++ b/src/Plugin/RulesExpression/Rule.php
@@ -11,15 +11,15 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\rules\Core\RulesActionBase;
 use Drupal\rules\Context\ContextConfig;
-use Drupal\rules\Engine\RulesActionContainerInterface;
-use Drupal\rules\Engine\RulesConditionContainerInterface;
-use Drupal\rules\Engine\RulesExpressionActionInterface;
-use Drupal\rules\Engine\RulesExpressionConditionInterface;
-use Drupal\rules\Engine\RulesExpressionInterface;
+use Drupal\rules\Engine\ActionExpressionContainerInterface;
+use Drupal\rules\Engine\ConditionExpressionContainerInterface;
+use Drupal\rules\Engine\ActionExpressionInterface;
+use Drupal\rules\Engine\ConditionExpressionInterface;
+use Drupal\rules\Engine\ExpressionInterface;
 use Drupal\rules\Engine\RulesExpressionTrait;
 use Drupal\rules\Engine\RulesState;
 use Drupal\rules\Exception\InvalidExpressionException;
-use Drupal\rules\Engine\RulesExpressionPluginManager;
+use Drupal\rules\Engine\ExpressionPluginManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -41,14 +41,14 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
   /**
    * List of conditions that must be met before actions are executed.
    *
-   * @var \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @var \Drupal\rules\Engine\ConditionExpressionContainerInterface
    */
   protected $conditions;
 
   /**
    * List of actions that get executed if the conditions are met.
    *
-   * @var \Drupal\rules\Engine\RulesActionContainerInterface
+   * @var \Drupal\rules\Engine\ActionExpressionContainerInterface
    */
   protected $actions;
 
@@ -61,10 +61,10 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
    *   The plugin_id for the plugin instance.
    * @param array $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\rules\Engine\RulesExpressionPluginManager $expression_manager
+   * @param \Drupal\rules\Engine\ExpressionPluginManager $expression_manager
    *   The rules expression plugin manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RulesExpressionPluginManager $expression_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ExpressionPluginManager $expression_manager) {
     // @todo: This needs to be removed again and we need to add proper derivative handling for Rules.
     if (isset($configuration['context_definitions'])) {
       $plugin_definition['context'] = $this->createContextDefinitions($configuration['context_definitions']);
@@ -155,7 +155,7 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
   /**
    * {@inheritdoc}
    */
-  public function setConditions(RulesConditionContainerInterface $conditions) {
+  public function setConditions(ConditionExpressionContainerInterface $conditions) {
     $this->conditions = $conditions;
     return $this;
   }
@@ -178,7 +178,7 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
   /**
    * {@inheritdoc}
    */
-  public function setActions(RulesActionContainerInterface $actions) {
+  public function setActions(ActionExpressionContainerInterface $actions) {
     $this->actions = $actions;
     return $this;
   }
@@ -186,11 +186,11 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
   /**
    * {@inheritdoc}
    */
-  public function addExpressionObject(RulesExpressionInterface $expression) {
-    if ($expression instanceof RulesExpressionConditionInterface) {
+  public function addExpressionObject(ExpressionInterface $expression) {
+    if ($expression instanceof ConditionExpressionInterface) {
       $this->conditions->addExpressionObject($expression);
     }
-    elseif ($expression instanceof RulesExpressionActionInterface) {
+    elseif ($expression instanceof ActionExpressionInterface) {
       $this->actions->addExpressionObject($expression);
     }
     else {

--- a/src/Plugin/RulesExpression/Rule.php
+++ b/src/Plugin/RulesExpression/Rule.php
@@ -10,6 +10,7 @@ namespace Drupal\rules\Plugin\RulesExpression;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\rules\Core\RulesActionBase;
+use Drupal\rules\Context\ContextConfig;
 use Drupal\rules\Engine\RulesActionContainerInterface;
 use Drupal\rules\Engine\RulesConditionContainerInterface;
 use Drupal\rules\Engine\RulesExpressionActionInterface;
@@ -139,8 +140,8 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
   /**
    * {@inheritdoc}
    */
-  public function addCondition($condition_id, $configuration = NULL) {
-    $this->conditions->addCondition($condition_id, $configuration);
+  public function addCondition($condition_id, ContextConfig $config = NULL) {
+    $this->conditions->addCondition($condition_id, $config);
     return $this;
   }
 
@@ -162,8 +163,8 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
   /**
    * {@inheritdoc}
    */
-  public function addAction($action_id, $configuration = NULL) {
-    $this->actions->addAction($action_id, $configuration);
+  public function addAction($action_id, ContextConfig $config = NULL) {
+    $this->actions->addAction($action_id, $config);
     return $this;
   }
 
@@ -201,9 +202,9 @@ class Rule extends RulesActionBase implements RuleInterface, ContainerFactoryPlu
   /**
    * {@inheritdoc}
    */
-  public function addExpression($plugin_id, $configuration = NULL) {
+  public function addExpression($plugin_id, ContextConfig $config = NULL) {
     return $this->addExpressionObject(
-      $this->expressionManager->createInstance($plugin_id, $configuration ?: [])
+      $this->expressionManager->createInstance($plugin_id, $config ? $config->toArray() : [])
     );
   }
 

--- a/src/Plugin/RulesExpression/RuleInterface.php
+++ b/src/Plugin/RulesExpression/RuleInterface.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\rules\Plugin\RulesExpression;
 
+use Drupal\rules\Context\ContextConfig;
 use Drupal\rules\Engine\RulesActionContainerInterface;
 use Drupal\rules\Engine\RulesConditionContainerInterface;
 use Drupal\rules\Engine\RulesExpressionActionInterface;
@@ -22,13 +23,13 @@ interface RuleInterface extends RulesExpressionContainerInterface, RulesExpressi
    *
    * @param string $condition_id
    *   The condition plugin id.
-   * @param array $configuration
+   * @param \Drupal\rules\Context\ContextConfig $config
    *   (optional) The configuration for the specified plugin.
    *
    * @return \Drupal\rules\Core\RulesConditionInterface
    *   The created condition.
    */
-  public function addCondition($condition_id, $configuration = NULL);
+  public function addCondition($condition_id, ContextConfig $config = NULL);
 
   /**
    * Returns the conditions container of this rule.
@@ -53,12 +54,12 @@ interface RuleInterface extends RulesExpressionContainerInterface, RulesExpressi
    *
    * @param string $action_id
    *   The action plugin id.
-   * @param array $configuration
+   * @param \Drupal\rules\Context\ContextConfig $config
    *   (optional) The configuration for the specified plugin.
    *
    * @return $this
    */
-  public function addAction($action_id, $configuration = NULL);
+  public function addAction($action_id, ContextConfig $config = NULL);
 
   /**
    * Returns the actions of this rule.

--- a/src/Plugin/RulesExpression/RuleInterface.php
+++ b/src/Plugin/RulesExpression/RuleInterface.php
@@ -8,15 +8,15 @@
 namespace Drupal\rules\Plugin\RulesExpression;
 
 use Drupal\rules\Context\ContextConfig;
-use Drupal\rules\Engine\RulesActionContainerInterface;
-use Drupal\rules\Engine\RulesConditionContainerInterface;
-use Drupal\rules\Engine\RulesExpressionActionInterface;
-use Drupal\rules\Engine\RulesExpressionContainerInterface;
+use Drupal\rules\Engine\ActionExpressionContainerInterface;
+use Drupal\rules\Engine\ConditionExpressionContainerInterface;
+use Drupal\rules\Engine\ActionExpressionInterface;
+use Drupal\rules\Engine\ExpressionContainerInterface;
 
 /**
  * Defines a rule.
  */
-interface RuleInterface extends RulesExpressionContainerInterface, RulesExpressionActionInterface {
+interface RuleInterface extends ExpressionContainerInterface, ActionExpressionInterface {
 
   /**
    * Creates a condition expression and adds it to the container.
@@ -34,7 +34,7 @@ interface RuleInterface extends RulesExpressionContainerInterface, RulesExpressi
   /**
    * Returns the conditions container of this rule.
    *
-   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @return \Drupal\rules\Engine\ConditionExpressionContainerInterface
    *   The condition container of this rule.
    */
   public function getConditions();
@@ -42,12 +42,12 @@ interface RuleInterface extends RulesExpressionContainerInterface, RulesExpressi
   /**
    * Sets the condition container.
    *
-   * @param \Drupal\rules\Engine\RulesConditionContainerInterface $conditions
+   * @param \Drupal\rules\Engine\ConditionExpressionContainerInterface $conditions
    *   The condition container to set.
    *
    * @return $this
    */
-  public function setConditions(RulesConditionContainerInterface $conditions);
+  public function setConditions(ConditionExpressionContainerInterface $conditions);
 
   /**
    * Creates an action expression and adds it to the container.
@@ -64,7 +64,7 @@ interface RuleInterface extends RulesExpressionContainerInterface, RulesExpressi
   /**
    * Returns the actions of this rule.
    *
-   * @return \Drupal\rules\Engine\RulesActionContainerInterface
+   * @return \Drupal\rules\Engine\ActionExpressionContainerInterface
    *   The action container of this rule.
    */
   public function getActions();
@@ -72,11 +72,11 @@ interface RuleInterface extends RulesExpressionContainerInterface, RulesExpressi
   /**
    * Sets the action container.
    *
-   * @param \Drupal\rules\Engine\RulesActionContainerInterface $actions
+   * @param \Drupal\rules\Engine\ActionExpressionContainerInterface $actions
    *   The action container to set.
    *
    * @return $this
    */
-  public function setActions(RulesActionContainerInterface $actions);
+  public function setActions(ActionExpressionContainerInterface $actions);
 
 }

--- a/src/Plugin/RulesExpression/RulesAction.php
+++ b/src/Plugin/RulesExpression/RulesAction.php
@@ -11,10 +11,10 @@ use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Action\ActionManager;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\rules\Core\RulesActionBase;
-use Drupal\rules\Engine\RulesExpressionActionInterface;
+use Drupal\rules\Engine\ActionExpressionInterface;
 use Drupal\rules\Engine\RulesExpressionTrait;
 use Drupal\rules\Engine\RulesState;
-use Drupal\rules\Engine\RulesDataProcessorManager;
+use Drupal\rules\Context\DataProcessorManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   label = @Translation("An executable action.")
  * )
  */
-class RulesAction extends RulesActionBase implements ContainerFactoryPluginInterface, RulesExpressionActionInterface {
+class RulesAction extends RulesActionBase implements ContainerFactoryPluginInterface, ActionExpressionInterface {
 
   use RulesExpressionTrait;
 
@@ -52,10 +52,10 @@ class RulesAction extends RulesActionBase implements ContainerFactoryPluginInter
    *   The plugin implementation definition.
    * @param \Drupal\Core\Action\ActionManager $action_manager
    *   The action manager.
-   * @param \Drupal\rules\Engine\RulesDataProcessorManager $processor_manager
+   * @param \Drupal\rules\Context\DataProcessorManager $processor_manager
    *   The data processor plugin manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ActionManager $action_manager, RulesDataProcessorManager $processor_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ActionManager $action_manager, DataProcessorManager $processor_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->actionManager = $action_manager;

--- a/src/Plugin/RulesExpression/RulesAnd.php
+++ b/src/Plugin/RulesExpression/RulesAnd.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\rules\Plugin\RulesExpression;
 
-use Drupal\rules\Engine\RulesConditionContainer;
+use Drupal\rules\Engine\ConditionExpressionContainer;
 use Drupal\rules\Engine\RulesState;
 
 /**
@@ -18,7 +18,7 @@ use Drupal\rules\Engine\RulesState;
  *   label = @Translation("Condition set (AND)")
  * )
  */
-class RulesAnd extends RulesConditionContainer {
+class RulesAnd extends ConditionExpressionContainer {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/RulesExpression/RulesCondition.php
+++ b/src/Plugin/RulesExpression/RulesCondition.php
@@ -10,10 +10,10 @@ namespace Drupal\rules\Plugin\RulesExpression;
 use Drupal\Core\Condition\ConditionManager;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\rules\Core\RulesConditionBase;
-use Drupal\rules\Engine\RulesExpressionConditionInterface;
+use Drupal\rules\Engine\ConditionExpressionInterface;
 use Drupal\rules\Engine\RulesExpressionTrait;
 use Drupal\rules\Engine\RulesState;
-use Drupal\rules\Engine\RulesDataProcessorManager;
+use Drupal\rules\Context\DataProcessorManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -27,7 +27,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   label = @Translation("An executable condition.")
  * )
  */
-class RulesCondition extends RulesConditionBase implements RulesExpressionConditionInterface, ContainerFactoryPluginInterface {
+class RulesCondition extends RulesConditionBase implements ConditionExpressionInterface, ContainerFactoryPluginInterface {
 
   use RulesExpressionTrait;
 
@@ -51,10 +51,10 @@ class RulesCondition extends RulesConditionBase implements RulesExpressionCondit
    *   The plugin implementation definition.
    * @param \Drupal\Core\Condition\ConditionManager $conditionManager
    *   The condition manager.
-   * @param \Drupal\rules\Engine\RulesDataProcessorManager $processor_manager
+   * @param \Drupal\rules\Context\DataProcessorManager $processor_manager
    *   The data processor plugin manager.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConditionManager $conditionManager, RulesDataProcessorManager $processor_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConditionManager $conditionManager, DataProcessorManager $processor_manager) {
     // Make sure defaults are applied.
     $configuration += $this->defaultConfiguration();
     parent::__construct($configuration, $plugin_id, $plugin_definition);

--- a/src/Plugin/RulesExpression/RulesOr.php
+++ b/src/Plugin/RulesExpression/RulesOr.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\rules\Plugin\RulesExpression;
 
-use Drupal\rules\Engine\RulesConditionContainer;
+use Drupal\rules\Engine\ConditionExpressionContainer;
 use Drupal\rules\Engine\RulesState;
 
 /**
@@ -18,7 +18,7 @@ use Drupal\rules\Engine\RulesState;
  *   label = @Translation("Condition set (OR)")
  * )
  */
-class RulesOr extends RulesConditionContainer {
+class RulesOr extends ConditionExpressionContainer {
 
   /**
    * {@inheritdoc}

--- a/src/Tests/DataProcessorTest.php
+++ b/src/Tests/DataProcessorTest.php
@@ -24,7 +24,7 @@ class DataProcessorTest extends RulesDrupalTestBase {
       // @todo Actually the data processor plugin only applies to numbers, so is
       // kind of an invalid configuration. Since the configuration is not
       // validated during execution this works for now.
-      'processor_mapping' => [
+      'context_processors' => [
         'message' => [
           'plugin' => 'rules_numeric_offset',
           'configuration' => [

--- a/src/Tests/NodeIntegrationTest.php
+++ b/src/Tests/NodeIntegrationTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\rules\Tests;
 
+use Drupal\rules\Context\ContextConfig;
 use Drupal\rules\Engine\RulesLog;
 
 /**
@@ -72,14 +73,14 @@ class NodeIntegrationTest extends RulesDrupalTestBase {
     ]);
 
     // Test that the long detailed data selector works.
-    $rule->addCondition('rules_test_string_condition', [
-      'context_mapping' => ['text:select' => 'node:uid:0:entity:name:0:value'],
-    ]);
+    $rule->addCondition('rules_test_string_condition', ContextConfig::create()
+      ->map('text', 'node:uid:0:entity:name:0:value')
+    );
 
     // Test that the shortened data selector without list indices.
-    $rule->addCondition('rules_test_string_condition', [
-      'context_mapping' => ['text:select' => 'node:uid:entity:name:value'],
-    ]);
+    $rule->addCondition('rules_test_string_condition', ContextConfig::create()
+      ->map('text', 'node:uid:entity:name:value')
+    );
 
     $rule->addAction('rules_test_log');
     $rule->setContextValue('node', $node);

--- a/src/Tests/RulesDrupalTestBase.php
+++ b/src/Tests/RulesDrupalTestBase.php
@@ -17,7 +17,7 @@ abstract class RulesDrupalTestBase extends KernelTestBase {
   /**
    * The expression plugin manager.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionPluginManager
+   * @var \Drupal\rules\Engine\ExpressionPluginManager
    */
   protected $expressionManager;
 

--- a/src/Tests/RulesEngineTest.php
+++ b/src/Tests/RulesEngineTest.php
@@ -127,9 +127,7 @@ class RulesEngineTest extends RulesDrupalTestBase {
 
     // The condition provides a "provided_text" variable.
     $rule->addCondition('rules_test_provider', ContextConfig::create()
-      // Expose the variable as 'newname'
-      // @todo: Cover key in ContextConfig.
-      ->setConfigKey('provides_mapping', ['provided_text' => 'newname'])
+      ->provideAs('provided_text', 'newname')
     );
 
     $state = new RulesState();
@@ -159,8 +157,7 @@ class RulesEngineTest extends RulesDrupalTestBase {
     // now.
     $rule->addAction('rules_test_string', ContextConfig::create()
       ->map('text', 'concatenated')
-      // @todo: Cover key in ContextConfig.
-      ->setConfigKey('provides_mapping', ['concatenated' => 'concatenated2'])
+      ->provideAs('concatenated', 'concatenated2')
     );
 
     $state = new RulesState();

--- a/src/Tests/RulesEngineTest.php
+++ b/src/Tests/RulesEngineTest.php
@@ -84,9 +84,9 @@ class RulesEngineTest extends RulesDrupalTestBase {
       ],
     ]);
 
-    $rule->addCondition('rules_test_string_condition', [
-      'context_mapping' => ['text:select' => 'test'],
-    ]);
+    $rule->addCondition('rules_test_string_condition', ContextConfig::create()
+      ->map('text', 'test')
+    );
 
     $rule->addAction('rules_test_log');
     $rule->setContextValue('test', 'test value');

--- a/src/Tests/RulesEngineTest.php
+++ b/src/Tests/RulesEngineTest.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\rules\Tests;
 
+use Drupal\rules\Context\ContextConfig;
 use Drupal\rules\Engine\RulesLog;
 use Drupal\rules\Engine\RulesState;
 
@@ -36,7 +37,7 @@ class RulesEngineTest extends RulesDrupalTestBase {
     // Create an 'and' condition container and add conditions to it.
     $and = $this->expressionManager->createAnd()
       ->addCondition('rules_test_false')
-      ->addExpressionObject($this->expressionManager->createCondition('rules_test_true')->negate())
+      ->addCondition('rules_test_true', ContextConfig::create()->negateResult())
       ->negate();
 
     // Test that the 'and' condition container evaluates to TRUE.
@@ -45,7 +46,7 @@ class RulesEngineTest extends RulesDrupalTestBase {
     // Create an 'or' condition container and add conditions to it, including
     // the previously created 'and' condition container.
     $or = $this->expressionManager->createOr()
-      ->addExpressionObject($this->expressionManager->createCondition('rules_test_true')->negate())
+      ->addCondition('rules_test_true', ContextConfig::create()->negateResult())
       ->addCondition('rules_test_false')
       ->addCondition($and);
 
@@ -106,9 +107,9 @@ class RulesEngineTest extends RulesDrupalTestBase {
     // The first condition provides a "provided_text" variable.
     $rule->addCondition('rules_test_provider');
     // The second condition consumes the variable.
-    $rule->addCondition('rules_test_string_condition', [
-      'context_mapping' => ['text:select' => 'provided_text'],
-    ]);
+    $rule->addCondition('rules_test_string_condition', ContextConfig::create()
+      ->map('text', 'provided_text')
+    );
 
     $rule->addAction('rules_test_log');
     $rule->execute();
@@ -125,10 +126,11 @@ class RulesEngineTest extends RulesDrupalTestBase {
     $rule = $this->expressionManager->createRule();
 
     // The condition provides a "provided_text" variable.
-    $rule->addCondition('rules_test_provider', [
-      // Expose the variable as 'newname'.
-      'provides_mapping' => ['provided_text' => 'newname'],
-    ]);
+    $rule->addCondition('rules_test_provider', ContextConfig::create()
+      // Expose the variable as 'newname'
+      // @todo: Cover key in ContextConfig.
+      ->setConfigKey('provides_mapping', ['provided_text' => 'newname'])
+    );
 
     $state = new RulesState();
     $rule->executeWithState($state);
@@ -142,22 +144,24 @@ class RulesEngineTest extends RulesDrupalTestBase {
    * Tests that multiple actions can consume and provide context variables.
    */
   public function testActionProvidedContext() {
+    // @todo: Convert the test to make use of actions instead of conditions.
     $rule = $this->expressionManager->createRule();
 
     // The condition provides a "provided_text" variable.
     $rule->addCondition('rules_test_provider');
 
     // The action provides a "concatenated" variable.
-    $rule->addAction('rules_test_string', [
-      'context_mapping' => ['text:select' => 'provided_text'],
-    ]);
+    $rule->addAction('rules_test_string', ContextConfig::create()
+      ->map('text', 'provided_text')
+    );
 
     // Add the same action again which will provide a "concatenated2" variable
     // now.
-    $rule->addAction('rules_test_string', [
-      'context_mapping' => ['text:select' => 'concatenated'],
-      'provides_mapping' => ['concatenated' => 'concatenated2'],
-    ]);
+    $rule->addAction('rules_test_string', ContextConfig::create()
+      ->map('text', 'concatenated')
+      // @todo: Cover key in ContextConfig.
+      ->setConfigKey('provides_mapping', ['concatenated' => 'concatenated2'])
+    );
 
     $state = new RulesState();
     $rule->executeWithState($state);

--- a/tests/src/Integration/RulesIntegrationTestBase.php
+++ b/tests/src/Integration/RulesIntegrationTestBase.php
@@ -12,8 +12,8 @@ use Drupal\Core\Cache\NullBackend;
 use Drupal\Core\Condition\ConditionManager;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\TypedData\TypedDataManager;
-use Drupal\rules\Engine\RulesDataProcessorManager;
-use Drupal\rules\Engine\RulesExpressionPluginManager;
+use Drupal\rules\Context\DataProcessorManager;
+use Drupal\rules\Engine\ExpressionPluginManager;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -47,12 +47,12 @@ abstract class RulesIntegrationTestBase extends UnitTestCase {
   protected $conditionManager;
 
   /**
-   * @var \Drupal\rules\Engine\RulesExpressionPluginManager
+   * @var \Drupal\rules\Engine\ExpressionPluginManager
    */
   protected $rulesExpressionManager;
 
   /**
-   * @var \Drupal\rules\Engine\RulesDataProcessorManager
+   * @var \Drupal\rules\Context\DataProcessorManager
    */
   protected $rulesDataProcessorManager;
 
@@ -124,14 +124,14 @@ abstract class RulesIntegrationTestBase extends UnitTestCase {
 
     $this->actionManager = new ActionManager($this->namespaces, $this->cacheBackend, $this->moduleHandler);
     $this->conditionManager = new ConditionManager($this->namespaces, $this->cacheBackend, $this->moduleHandler);
-    $this->rulesExpressionManager = new RulesExpressionPluginManager($this->namespaces, $this->moduleHandler);
+    $this->rulesExpressionManager = new ExpressionPluginManager($this->namespaces, $this->moduleHandler);
 
     $this->classResolver = $this->getMockBuilder('Drupal\Core\DependencyInjection\ClassResolverInterface')
       ->disableOriginalConstructor()
       ->getMock();
 
     $this->typedDataManager = new TypedDataManager($this->namespaces, $this->cacheBackend, $this->moduleHandler, $this->classResolver);
-    $this->rulesDataProcessorManager = new RulesDataProcessorManager($this->namespaces, $this->moduleHandler);
+    $this->rulesDataProcessorManager = new DataProcessorManager($this->namespaces, $this->moduleHandler);
 
     $this->aliasManager = $this->getMockBuilder('Drupal\Core\Path\AliasManagerInterface')
       ->disableOriginalConstructor()

--- a/tests/src/Unit/AutoSaveTest.php
+++ b/tests/src/Unit/AutoSaveTest.php
@@ -20,7 +20,7 @@ class AutoSaveTest extends RulesUnitTestBase {
    * Tests auto saving after an action execution.
    */
   public function testActionAutoSave() {
-    $processor_manager = $this->getMockBuilder('Drupal\rules\Engine\RulesDataProcessorManager')
+    $processor_manager = $this->getMockBuilder('Drupal\rules\Context\DataProcessorManager')
       ->disableOriginalConstructor()
       ->getMock();
 

--- a/tests/src/Unit/RuleTest.php
+++ b/tests/src/Unit/RuleTest.php
@@ -18,7 +18,7 @@ class RuleTest extends RulesUnitTestBase {
   /**
    * The rules expression plugin manager.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionPluginManager
+   * @var \Drupal\rules\Engine\ExpressionPluginManager
    */
   protected $expressionManager;
 
@@ -32,14 +32,14 @@ class RuleTest extends RulesUnitTestBase {
   /**
    * The primary condition container of the rule.
    *
-   * @var \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @var \Drupal\rules\Engine\ConditionExpressionContainerInterface
    */
   protected $conditions;
 
   /**
    * The primary action container of the rule.
    *
-   * @var \Drupal\rules\Engine\RulesActionContainerInterface
+   * @var \Drupal\rules\Engine\ActionExpressionContainerInterface
    */
   protected $actions;
 
@@ -49,7 +49,7 @@ class RuleTest extends RulesUnitTestBase {
   public function setUp() {
     parent::setUp();
 
-    $this->expressionManager = $this->getMockBuilder('Drupal\rules\Engine\RulesExpressionPluginManager')
+    $this->expressionManager = $this->getMockBuilder('Drupal\rules\Engine\ExpressionPluginManager')
       ->disableOriginalConstructor()
       ->getMock();
 

--- a/tests/src/Unit/RulesAndTest.php
+++ b/tests/src/Unit/RulesAndTest.php
@@ -18,7 +18,7 @@ class RulesAndTest extends RulesUnitTestBase {
   /**
    * The 'and' condition container being tested.
    *
-   * @var \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @var \Drupal\rules\Engine\ConditionExpressionContainerInterface
    */
   protected $and;
 

--- a/tests/src/Unit/RulesConditionContainerTest.php
+++ b/tests/src/Unit/RulesConditionContainerTest.php
@@ -8,7 +8,7 @@
 namespace Drupal\Tests\rules\Unit;
 
 /**
- * @coversDefaultClass \Drupal\rules\Engine\RulesConditionContainer
+ * @coversDefaultClass \Drupal\rules\Engine\ConditionExpressionContainer
  * @group rules
  */
 class RulesConditionContainerTest extends RulesUnitTestBase {
@@ -21,12 +21,12 @@ class RulesConditionContainerTest extends RulesUnitTestBase {
    * @param string $class
    *   The name of the created mock class.
    *
-   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @return \Drupal\rules\Engine\ConditionExpressionContainerInterface
    *   The mocked condition container.
    */
   protected function getMockConditionContainer(array $methods = [], $class = 'RulesConditionContainerMock') {
     return $this->getMockForAbstractClass(
-      'Drupal\rules\Engine\RulesConditionContainer', [], $class, FALSE, TRUE, TRUE, $methods
+      'Drupal\rules\Engine\ConditionExpressionContainer', [], $class, FALSE, TRUE, TRUE, $methods
     );
   }
 

--- a/tests/src/Unit/RulesConditionContainerTest.php
+++ b/tests/src/Unit/RulesConditionContainerTest.php
@@ -33,9 +33,9 @@ class RulesConditionContainerTest extends RulesUnitTestBase {
   /**
    * Tests adding conditions to the condition container.
    *
-   * @covers ::addCondition
+   * @covers ::addExpressionObject
    */
-  public function testAddCondition() {
+  public function testAddExpressionObject() {
     $container = $this->getMockConditionContainer();
     $container->addExpressionObject($this->trueCondition);
 

--- a/tests/src/Unit/RulesConditionTest.php
+++ b/tests/src/Unit/RulesConditionTest.php
@@ -120,7 +120,7 @@ class RulesConditionTest extends RulesUnitTestBase {
   public function testDataProcessor() {
     $condition = new RulesCondition([
       'condition_id' => 'rules_or',
-      'processor_mapping' => [
+      'context_processors' => [
         'test' => [
           // We don't care about the data processor plugin name and
           // configuration since we will use a mock anyway.

--- a/tests/src/Unit/RulesConditionTest.php
+++ b/tests/src/Unit/RulesConditionTest.php
@@ -26,7 +26,7 @@ class RulesConditionTest extends RulesUnitTestBase {
   /**
    * The mocked data processor manager.
    *
-   * @var \Drupal\rules\Engine\RulesDataProcessorManager
+   * @var \Drupal\rules\Context\DataProcessorManager
    */
   protected $processorManager;
 
@@ -59,7 +59,7 @@ class RulesConditionTest extends RulesUnitTestBase {
       ->disableOriginalConstructor()
       ->getMock();
 
-    $this->processorManager = $this->getMockBuilder('Drupal\rules\Engine\RulesDataProcessorManager')
+    $this->processorManager = $this->getMockBuilder('Drupal\rules\Context\DataProcessorManager')
       ->disableOriginalConstructor()
       ->getMock();
 
@@ -158,7 +158,7 @@ class RulesConditionTest extends RulesUnitTestBase {
       ->method('createInstance')
       ->will($this->returnValue($this->trueCondition));
 
-    $data_processor = $this->getMock('Drupal\rules\Engine\RulesDataProcessorInterface');
+    $data_processor = $this->getMock('Drupal\rules\Context\DataProcessorInterface');
     $data_processor->expects($this->once())
       ->method('process')
       ->with('old_value')

--- a/tests/src/Unit/RulesOrTest.php
+++ b/tests/src/Unit/RulesOrTest.php
@@ -18,7 +18,7 @@ class RulesOrTest extends RulesUnitTestBase {
   /**
    * The 'or' condition container being tested.
    *
-   * @var \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @var \Drupal\rules\Engine\ConditionExpressionContainerInterface
    */
   protected $or;
 

--- a/tests/src/Unit/RulesUnitTestBase.php
+++ b/tests/src/Unit/RulesUnitTestBase.php
@@ -19,28 +19,28 @@ abstract class RulesUnitTestBase extends UnitTestCase {
   /**
    * A mocked condition that always evaluates to TRUE.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionConditionInterface
+   * @var \Drupal\rules\Engine\ConditionExpressionInterface
    */
   protected $trueCondition;
 
   /**
    * A mocked condition that always evaluates to FALSE.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionConditionInterface
+   * @var \Drupal\rules\Engine\ConditionExpressionInterface
    */
   protected $falseCondition;
 
   /**
    * A mocked dummy action object.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionActionInterface
+   * @var \Drupal\rules\Engine\ActionExpressionInterface
    */
   protected $testAction;
 
   /**
    * The mocked expression manager object.
    *
-   * @var \Drupal\rules\Engine\RulesExpressionPluginManager
+   * @var \Drupal\rules\Engine\ExpressionPluginManager
    */
   protected $expressionManager;
 
@@ -50,7 +50,7 @@ abstract class RulesUnitTestBase extends UnitTestCase {
   public function setUp() {
     parent::setUp();
 
-    $this->trueCondition = $this->getMock('Drupal\rules\Engine\RulesExpressionConditionInterface');
+    $this->trueCondition = $this->getMock('Drupal\rules\Engine\ConditionExpressionInterface');
 
     $this->trueCondition->expects($this->any())
       ->method('execute')
@@ -64,7 +64,7 @@ abstract class RulesUnitTestBase extends UnitTestCase {
       ->method('evaluate')
       ->will($this->returnValue(TRUE));
 
-    $this->falseCondition = $this->getMock('Drupal\rules\Engine\RulesExpressionConditionInterface');
+    $this->falseCondition = $this->getMock('Drupal\rules\Engine\ConditionExpressionInterface');
 
     $this->falseCondition->expects($this->any())
       ->method('execute')
@@ -78,9 +78,9 @@ abstract class RulesUnitTestBase extends UnitTestCase {
       ->method('evaluate')
       ->will($this->returnValue(FALSE));
 
-    $this->testAction = $this->getMock('Drupal\rules\Engine\RulesExpressionActionInterface');
+    $this->testAction = $this->getMock('Drupal\rules\Engine\ActionExpressionInterface');
 
-    $this->expressionManager = $this->getMockBuilder('Drupal\rules\Engine\RulesExpressionPluginManager')
+    $this->expressionManager = $this->getMockBuilder('Drupal\rules\Engine\ExpressionPluginManager')
       ->disableOriginalConstructor()
       ->getMock();
   }
@@ -216,7 +216,7 @@ abstract class RulesUnitTestBase extends UnitTestCase {
    * @param array $methods
    *   (optional) The methods to mock.
    *
-   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @return \Drupal\rules\Engine\ConditionExpressionContainerInterface
    *   The mocked 'and' condition container.
    */
   protected function getMockAnd(array $methods = []) {
@@ -241,7 +241,7 @@ abstract class RulesUnitTestBase extends UnitTestCase {
    * @param array $methods
    *   (optional) The methods to mock.
    *
-   * @return \Drupal\rules\Engine\RulesConditionContainerInterface
+   * @return \Drupal\rules\Engine\ConditionExpressionContainerInterface
    *   The mocked 'or' condition container.
    */
   protected function getMockOr(array $methods = []) {
@@ -266,7 +266,7 @@ abstract class RulesUnitTestBase extends UnitTestCase {
    * @param array $methods
    *   (optional) The methods to mock.
    *
-   * @return \Drupal\rules\Engine\RulesActionContainerInterface
+   * @return \Drupal\rules\Engine\ActionExpressionContainerInterface
    *   The mocked action container.
    */
   protected function getMockActionSet(array $methods = []) {


### PR DESCRIPTION
Renamed classes and interface to have consistent and meaningful naming, moved data processors below Context namespace - as they are about processing context and not necessarily part of the Engine.

Warning: This builds upon
https://github.com/fago/rules/pull/138
- thus the other one needs to be dealt wirth first.
