### PR TITLE
Replaced all occurrences of String class with the SafeMarkup equivalent

### DIFF
--- a/src/Context/ContextHandlerTrait.php
+++ b/src/Context/ContextHandlerTrait.php
@@ -8,7 +8,7 @@
 namespace Drupal\rules\Context;
 
 use Drupal\Component\Plugin\ContextAwarePluginInterface;
-use Drupal\Component\Utility\String;
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\rules\Exception\RulesEvaluationException;
 use Drupal\rules\Engine\RulesState;
 
@@ -51,7 +51,7 @@ trait ContextHandlerTrait {
       // @todo: This misses support for picking up pre-defined values here.
 
       elseif ($definition->isRequired()) {
-        throw new RulesEvaluationException(String::format('Required context @name is missing for plugin @plugin.', [
+        throw new RulesEvaluationException(SafeMarkup::format('Required context @name is missing for plugin @plugin.', [
           '@name' => $name,
           '@plugin' => $plugin->getPluginId(),
         ]));

--- a/src/Engine/RulesState.php
+++ b/src/Engine/RulesState.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\rules\Engine;
 
-use Drupal\Component\Utility\String;
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Plugin\Context\ContextInterface;
 use Drupal\Core\TypedData\ComplexDataInterface;
@@ -88,7 +88,7 @@ class RulesState {
    */
   public function getVariable($name) {
     if (!array_key_exists($name, $this->variables)) {
-      throw new RulesEvaluationException(String::format('Unable to get variable @name, it is not defined.', [
+      throw new RulesEvaluationException(SafeMarkup::format('Unable to get variable @name, it is not defined.', [
         '@name' => $name,
       ]));
     }
@@ -125,7 +125,7 @@ class RulesState {
       if ($typed_data instanceof DataReferenceInterface) {
         $typed_data = $typed_data->getTarget();
         if ($typed_data === NULL) {
-          throw new RulesEvaluationException(String::format('Unable to apply data selector @current_selector. The specified reference is NULL.', [
+          throw new RulesEvaluationException(SafeMarkup::format('Unable to apply data selector @current_selector. The specified reference is NULL.', [
             '@current_selector' => $current_selector,
           ]));
         }
@@ -155,14 +155,14 @@ class RulesState {
         }
         catch (\InvalidArgumentException $e) {
           // In case of an exception, re-throw it.
-          throw new RulesEvaluationException(String::format('Unable to apply data selector @current_selector: @error', [
+          throw new RulesEvaluationException(SafeMarkup::format('Unable to apply data selector @current_selector: @error', [
             '@current_selector' => $current_selector,
             '@error' => $e->getMessage(),
           ]));
         }
       }
       else {
-        throw new RulesEvaluationException(String::format('Unable to apply data selector @current_selector. The specified variable is not a list or a complex structure: @name.', [
+        throw new RulesEvaluationException(SafeMarkup::format('Unable to apply data selector @current_selector. The specified variable is not a list or a complex structure: @name.', [
           '@current_selector' => $current_selector,
           '@name' => $name,
         ]));

--- a/src/Plugin/Action/DataConvert.php
+++ b/src/Plugin/Action/DataConvert.php
@@ -7,8 +7,8 @@
 
 namespace Drupal\rules\Plugin\Action;
 
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\rules\Core\RulesActionBase;
-use Drupal\Component\Utility\String;
 
 /**
  * @Action(
@@ -73,7 +73,7 @@ class DataConvert extends RulesActionBase {
           $value = round($value);
           break;
         default:
-          throw new \InvalidArgumentException(String::format('Unknown rounding behavior: @rounding_behavior', [
+          throw new \InvalidArgumentException(SafeMarkup::format('Unknown rounding behavior: @rounding_behavior', [
             '@rounding_behavior' => $rounding_behavior,
           ]));
       }
@@ -90,7 +90,7 @@ class DataConvert extends RulesActionBase {
         $result = strval($value);
         break;
       default:
-        throw new \InvalidArgumentException(String::format('Unknown target type: @type', [
+        throw new \InvalidArgumentException(SafeMarkup::format('Unknown target type: @type', [
           '@type' => $target_type,
         ]));
     }

--- a/src/Plugin/Action/SystemMessage.php
+++ b/src/Plugin/Action/SystemMessage.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\rules\Plugin\Action;
 
-use Drupal\Component\Utility\String;
+use Drupal\Component\Utility\SafeMarkup;
 use Drupal\rules\Core\RulesActionBase;
 
 /**
@@ -49,7 +49,7 @@ class SystemMessage extends RulesActionBase {
   public function execute() {
     // @todo Should we do the sanitization somewhere else? D7 had the sanitize
     // flag in the context definition.
-    $message = String::checkPlain($this->getContextValue('message'));
+    $message = SafeMarkup::checkPlain($this->getContextValue('message'));
     $type = $this->getContextValue('type');
     $repeat = (bool) $this->getContextValue('repeat');
     drupal_set_message($message, $type, $repeat);


### PR DESCRIPTION
Replaced all occurrences of String class with the SafeMarkup equivalent and updated the usage at the top of files.
