### PR TITLE
Address a couple of spelling mistakes in \Drupal\Tests\rules\Integration\Action\EntityCreateTest

### DIFF
--- a/tests/src/Integration/Action/EntityCreateTest.php
+++ b/tests/src/Integration/Action/EntityCreateTest.php
@@ -35,7 +35,7 @@ class EntityCreateTest extends RulesEntityIntegrationTestBase {
     parent::setUp();
 
     // Prepare mocked bundle field definition. This is needed because
-    // EntityCreateDeriver adds required contexs for required fields, and
+    // EntityCreateDeriver adds required contexts for required fields, and
     // assumes that the bundle field is required.
     $this->bundleFieldDefinition = $this->getMockBuilder('Drupal\Core\Field\BaseFieldDefinition')
       ->disableOriginalConstructor()
@@ -106,7 +106,7 @@ class EntityCreateTest extends RulesEntityIntegrationTestBase {
       ->method('getStorage')
       ->willReturn($this->entityTypeStorage);
 
-    // Return a mocked list of base fields defintions.
+    // Return a mocked list of base fields definitions.
     $this->entityManager
       ->expects($this->any())
       ->method('getBaseFieldDefinitions')


### PR DESCRIPTION
I encountered this minor spelling errors while working on the following issue: https://www.drupal.org/node/2471447
