### PR TITLE
Issue #2565335: ReactionRule configentity must implement setExpressio…

### DIFF
--- a/src/Entity/ReactionRule.php
+++ b/src/Entity/ReactionRule.php
@@ -116,6 +116,22 @@ class ReactionRule extends ConfigEntityBase {
    * @var string
    */
   protected $module = 'rules';
+    
+  /**
+   * Sets a Rules expression instance for this Reaction rule.
+   *
+   * @param \Drupal\rules\Engine\ExpressionInterface $expression
+   *   The expression to set.
+   *
+   * @return $this
+   */
+  public function setExpression(ExpressionInterface $expression) {
+    $this->expression = $expression;
+    $this->expression_id = $expression->getPluginId();
+    $this->configuration = $expression->getConfiguration();
+    return $this;
+  }
+  
 
   /**
    * Gets a Rules expression instance for this Reaction rule.


### PR DESCRIPTION
Fixes an issue that prevents ReactionRule config entities from successfully saving to the config store.

This may be better accomplished by factoring ReactionRule and RuleComponent to share this setExpression().
