### PR TITLE
Issue #2573007: RulesConditionBase::evaluate() must return a value

### DIFF
--- a/src/Core/RulesConditionBase.php
+++ b/src/Core/RulesConditionBase.php
@@ -45,7 +45,7 @@ abstract class RulesConditionBase extends ConditionPluginBase implements RulesCo
     foreach ($this->getContexts() as $name => $context) {
       $args[$name] = $context->getContextValue();
     }
-    call_user_func_array([$this, 'doEvaluate'], $args);
+    return call_user_func_array([$this, 'doEvaluate'], $args);
   }
 
 }


### PR DESCRIPTION
This fixes the problem.  However, there already is a test for this.
The test can't be right, since it did not pick this up!!
