### PR TITLE
Issue #2572945: doExecute / doEvaluate for DataIsEmpty

### DIFF
--- a/src/Plugin/Condition/DataIsEmpty.php
+++ b/src/Plugin/Condition/DataIsEmpty.php
@@ -36,17 +36,10 @@ class DataIsEmpty extends RulesConditionBase {
   /**
    * {@inheritdoc}
    */
-  public function evaluate() {
-    $data = $this->getContext('data')->getContextData();
+  protected function doEvaluate($data) {
     if ($data instanceof ComplexDataInterface || $data instanceof ListInterface) {
       return $data->isEmpty();
     }
-    $value = $data->getValue();
-    // For some primitives we can rely on PHP's type casting to boolean.
-    if ($data instanceof StringInterface || $data instanceof IntegerInterface || $data instanceof BooleanInterface) {
-      return !isset($value) || !$value;
-    }
-    return !isset($value);
+    return empty($data);
   }
-
 }

--- a/tests/src/Integration/Condition/DataIsEmptyTest.php
+++ b/tests/src/Integration/Condition/DataIsEmptyTest.php
@@ -9,7 +9,10 @@ namespace Drupal\Tests\rules\Integration\Condition;
 
 use Drupal\Core\Plugin\Context\Context;
 use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\Core\TypedData\DataDefinitionInterface;
+use Drupal\Core\TypedData\TypedDataManagerInterface;
 use Drupal\Tests\rules\Integration\RulesIntegrationTestBase;
+use Prophecy\Argument;
 
 /**
  * @coversDefaultClass \Drupal\rules\Plugin\Condition\DataIsEmpty
@@ -25,12 +28,77 @@ class DataIsEmptyTest extends RulesIntegrationTestBase {
   protected $condition;
 
   /**
+   * Real TypedDataManager.
+   *
+   * We will mock some of its methods for this test class.
+   *
+   * @var \Drupal\Core\TypedData\TypedDataManagerInterface
+   */
+  protected $realTypedDataManager;
+
+  /**
+   * Mocked data definition.
+   *
+   * @var Prophecy
+   */
+  protected $dataDefinition;
+
+
+  /**
    * {@inheritdoc}
    */
   public function setUp() {
     parent::setUp();
-
     $this->condition = $this->conditionManager->createInstance('rules_data_is_empty');
+
+    // We need better control of the TypedDataManager, so let's put a mock in front of it.
+    $typed_data_manager = $this->realTypedDataManager = $this->typedDataManager;
+
+    // We want to model a complex data type that won't "auto-unwrap", since we
+    // are testing code that wants to try operations on complex typed data.
+    // Let's call it a "duck", since if it walks like a duck, and talks like a duck,
+    // then most likely it is complex data.
+    $data_definition_interface = $this->prophesize(DataDefinitionInterface::class);
+    $data_definition_interface->getDataType()->willReturn('duck');
+    $data_definition_interface->isList()->willReturn(TRUE);
+    $this->dataDefinition = $data_definition_interface->reveal();
+    $typed_data_definition = [
+      'id' => 'duck',
+    ];
+
+    // Now tell our mocked typed data manager all about our 'duck'.  Since it's
+    // just the 'duck' that we want to model, we will will mock our duck, but
+    // let the real TDM handle anything else, since we are also testing a number
+    // of other types.
+    $tdm_mock = $this->prophesize(TypedDataManagerInterface::class);
+    $tdm_mock
+      ->create(Argument::any())->will(function($args) use($typed_data_manager) {
+        $definition = $args[0];
+        return $typed_data_manager->create($definition);
+      });
+    $tdm_mock->createDataDefinition('duck')->willReturn($data_definition_interface->reveal());
+    $tdm_mock->createDataDefinition(Argument::any())->will(function($args) use($typed_data_manager) {
+      $type = $args[0];
+      return $typed_data_manager->createDataDefinition($type);
+    });
+    $tdm_mock->getDefinition('duck')->willReturn($typed_data_definition);
+    $tdm_mock->getDefinition(Argument::type('string'))->will(function($args) use($typed_data_manager) {
+      $type = $args[0];
+      return $typed_data_manager->getDefinition($type);
+    });
+    $tdm_mock->getCanonicalRepresentation(Argument::any())->will(function($args) use($typed_data_manager) {
+      $data = $args[0];
+      $type = $data->getDataDefinition()->getDataType();
+      if ($type == 'duck') {
+        // We do not want this data unwrapped, so just pass it back.
+        return $data;
+      }
+      return $typed_data_manager->getCanonicalRepresentation($data);
+    });
+
+    // Update our TDM, and make sure container-aware classes see it.
+    $this->typedDataManager = $tdm_mock->reveal();
+    $this->container->set('typed_data_manager', $this->typedDataManager);
   }
 
   /**
@@ -39,23 +107,30 @@ class DataIsEmptyTest extends RulesIntegrationTestBase {
    * @covers ::evaluate
    */
   public function testConditionEvaluation() {
-    // Test a ComplexDataInterface object.
-    $entity_adapter_empty = $this->prophesize(ComplexDataInterface::class);
-    $entity_adapter_empty->isEmpty()->willReturn(TRUE)->shouldBeCalledTimes(1);
+    // A couple of complex data instances. First, a 'duck' that isn't empty.
+    $complex_data_empty = $this->prophesize(ComplexDataInterface::class);
+    $complex_data_empty->isEmpty()->willReturn(TRUE)->shouldBeCalledTimes(1);
+    $complex_data_empty->getDataDefinition()->willReturn($this->dataDefinition);
+    $complex_data_empty->getValue()->willReturn(FALSE);
 
     $context = $this->condition->getContext('data');
-    $context = Context::createFromContext($context, $entity_adapter_empty->reveal());
+    $context = Context::createFromContext($context, $complex_data_empty->reveal());
     $this->condition->setContext('data', $context);
     $this->assertTrue($this->condition->evaluate());
 
-    $entity_adapter_full = $this->prophesize(ComplexDataInterface::class);
-    $entity_adapter_full->isEmpty()->willReturn(FALSE)->shouldBeCalledTimes(1);
+    $complex_data_full = $this->prophesize(ComplexDataInterface::class);
+    $complex_data_full->isEmpty()->willReturn(FALSE)->shouldBeCalledTimes(1);
+    $complex_data_full->getDataDefinition()->willReturn($this->dataDefinition);
+    $complex_data_full->getValue()->willReturn(TRUE);
 
-    $context = Context::createFromContext($context, $entity_adapter_full->reveal());
+    $context = Context::createFromContext($context, $complex_data_full->reveal());
     $this->condition->setContext('data', $context);
     $this->assertFalse($this->condition->evaluate());
 
-    // These should all return FALSE.
+    //
+    // These next few items should all return FALSE.
+    //
+
     // A non-empty array.
     $context = Context::createFromContext($context, $this->getTypedData('list', [1, 2, 3]));
     $this->condition->setContext('data', $context);
@@ -80,7 +155,10 @@ class DataIsEmptyTest extends RulesIntegrationTestBase {
     $this->condition->setContext('data', $context);
     $this->assertFalse($this->condition->evaluate());
 
+    //
     // These should all return TRUE.
+    //
+
     // An empty array.
     $context = Context::createFromContext($context, $this->getTypedData('list', []));
     $this->condition->setContext('data', $context);


### PR DESCRIPTION
Drupal Issue: https://www.drupal.org/node/2572945

Implementation of the modified plugin, and the modified test.

<del>The test of complex data interfaces no longer works, and may not even be relevant anymore, since RuleConditionBase::evaluate() unwraps the data for us.  I've commented out that part of the test.</del>


To get the tests to work, the mocks needed to be changed so that the complex data object would not get automatically unwrapped.  The mocks verify that the object indeed gets passed into the condition, and behaves as expected.
