### PR TITLE
Issue #2573045: doEvaluate for rules_data_comparison

### DIFF
--- a/src/Plugin/Condition/DataComparison.php
+++ b/src/Plugin/Condition/DataComparison.php
@@ -24,6 +24,7 @@ use Drupal\rules\Core\RulesConditionBase;
  *     "operator" = @ContextDefinition("string",
  *       label = @Translation("Operator"),
  *       description = @Translation("The comparison operator."),
+ *       default_value = "==",
  *       required = FALSE
  *     ),
  *     "value" = @ContextDefinition("any",
@@ -39,13 +40,25 @@ use Drupal\rules\Core\RulesConditionBase;
 class DataComparison extends RulesConditionBase {
 
   /**
-   * {@inheritdoc}
+   * Evaluate the data comparison.
+   *
+   * @param mixed $data
+   *   Supplied data to test.
+   * @param string $operator
+   *   Data comparison operator. Typically one of:
+   *     - "=="
+   *     - "<"
+   *     - ">"
+   *     - "contains" (for strings or arrays)
+   *     - "IN" (for arrays or lists).
+   * @param mixed $value
+   *   The value to be compared against $data.
+   *
+   * @return bool
+   *   The evaluation of the condition.
    */
-  public function evaluate() {
-    $data = $this->getContextValue('data');
-    $operator = $this->getContext('operator')->getContextData() ? $this->getContextValue('operator') : '==';
-    $value = $this->getContextValue('value');
-
+  protected function doEvaluate($data, $operator, $value) {
+    $operator = $operator ? $operator : '==';
     switch ($operator) {
       case '<':
         return $data < $value;


### PR DESCRIPTION
Drupal issue https://www.drupal.org/node/2573045

<del>I needed to swap the order of the context items, since it appears that PHP gets very annoyed when an optional argument is not at the end of the list.  In particular: if you pass the non-final argument as NULL, call_func_array does strange things.

Test needed to be tweaked as well; it seems to matter what order setContextValue() is called, so 'operator' is now always last.</del>

Current Rules HEAD now does the right thing with preserving annotation order.
