### PR TITLE
Issue #2573823: Context in Rules plugins does not respect annotation order

### DIFF
--- a/src/Core/RulesActionBase.php
+++ b/src/Core/RulesActionBase.php
@@ -8,14 +8,13 @@
 namespace Drupal\rules\Core;
 
 use Drupal\Core\Access\AccessResultForbidden;
-use Drupal\Core\Plugin\ContextAwarePluginBase;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\rules\Context\ContextProviderTrait;
 
 /**
  * Base class for rules actions.
  */
-abstract class RulesActionBase extends ContextAwarePluginBase implements RulesActionInterface {
+abstract class RulesActionBase extends RulesPluginBase implements RulesActionInterface {
 
   use ContextProviderTrait;
   use ExecutablePluginTrait;

--- a/src/Core/RulesConditionBase.php
+++ b/src/Core/RulesConditionBase.php
@@ -48,4 +48,18 @@ abstract class RulesConditionBase extends ConditionPluginBase implements RulesCo
     return call_user_func_array([$this, 'doEvaluate'], $args);
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * Override so we get context in cannonical order.
+   */
+  public function getContexts() {
+    // Make sure all context objects are initialized.
+    $ordered_context = [];
+    foreach ($this->getContextDefinitions() as $name => $definition) {
+      $ordered_context[$name] = $this->getContext($name);
+    }
+    return $ordered_context;
+  }
+
 }

--- a/src/Core/RulesEvent.php
+++ b/src/Core/RulesEvent.php
@@ -7,11 +7,10 @@
 
 namespace Drupal\rules\Core;
 
-use Drupal\Core\Plugin\ContextAwarePluginBase;
 
 /**
  * Base class for rules events.
  */
-class RulesEvent extends ContextAwarePluginBase implements RulesEventInterface {
+class RulesEvent extends RulesPluginBase implements RulesEventInterface {
 
 }

--- a/src/Core/RulesPluginBase.php
+++ b/src/Core/RulesPluginBase.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Core\Plugin\ContextAwarePluginBase.
+ */
+
+namespace Drupal\rules\Core;
+
+use Drupal\Core\Plugin\ContextAwarePluginBase;
+
+/**
+ * Base class for rules plugins.
+ */
+abstract class RulesPluginBase extends ContextAwarePluginBase {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Override so we get context in cannonical order.
+   */
+  public function getContexts() {
+    // Make sure all context objects are initialized.
+    $ordered_context = [];
+    foreach ($this->getContextDefinitions() as $name => $definition) {
+      $ordered_context[$name] = $this->getContext($name);
+    }
+    return $ordered_context;
+  }
+
+}

--- a/src/Engine/ExpressionBase.php
+++ b/src/Engine/ExpressionBase.php
@@ -7,14 +7,14 @@
 
 namespace Drupal\rules\Engine;
 
-use Drupal\Core\Plugin\ContextAwarePluginBase;
 use Drupal\rules\Context\ContextDefinition;
 use Drupal\rules\Context\ContextProviderTrait;
+use Drupal\rules\Core\RulesPluginBase;
 
 /**
  * Base class for rules actions.
  */
-abstract class ExpressionBase extends ContextAwarePluginBase implements ExpressionInterface {
+abstract class ExpressionBase extends RulesPluginBase implements ExpressionInterface {
 
   use ContextProviderTrait;
 


### PR DESCRIPTION
Drupal issue:  https://www.drupal.org/node/2573823

Here's a work-around that works in Rules.

Note: I only saw fago's comment in the issue queue after I finished this.  So my solution will be a little different than what he suggested there. 

It does run all of the existing tests for rules, and also works with DataComparisonTest.
