### PR TITLE
Issue #2575977: remove use of now protected Context::setContextValue(…

### DIFF
--- a/src/Context/ContextHandlerTrait.php
+++ b/src/Context/ContextHandlerTrait.php
@@ -9,6 +9,7 @@ namespace Drupal\rules\Context;
 
 use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Plugin\ContextAwarePluginInterface as CoreContextAwarePluginInterface;
+use Drupal\Core\Plugin\Context\Context;
 use Drupal\rules\Engine\RulesStateInterface;
 use Drupal\rules\Exception\RulesEvaluationException;
 
@@ -28,6 +29,16 @@ trait ContextHandlerTrait {
    * @var \Drupal\rules\Context\DataProcessorManager
    */
   protected $processorManager;
+  
+  /**
+   * Sets or replaces a plugin context with a set value
+   */
+  protected function setPluginContext($plugin, $name, $typed_data) {
+    $context_def = $plugin->getContextDefinition($name);
+    $context = new Context($context_def, $typed_data);
+    $plugin->setContext($name, $context);
+    
+  }
 
   /**
    * Maps variables from rules state into the plugin context.
@@ -54,7 +65,7 @@ trait ContextHandlerTrait {
             '@plugin' => $plugin->getPluginId(),
           ]));
         }
-        $plugin->getContext($name)->setContextData($typed_data);
+        $this->setPluginContext($plugin, $name, $typed_data);
       }
       elseif (isset($this->configuration['context_values'])
         && array_key_exists($name, $this->configuration['context_values'])
@@ -66,8 +77,7 @@ trait ContextHandlerTrait {
             '@plugin' => $plugin->getPluginId(),
           ]));
         }
-
-        $plugin->getContext($name)->setContextValue($this->configuration['context_values'][$name]);
+        $this->setPluginContext($plugin, $name, $this->configuration['context_values'][$name]);
       }
       elseif ($definition->isRequired()) {
         throw new RulesEvaluationException(SafeMarkup::format('Required context @name is missing for plugin @plugin.', [

--- a/src/Context/ContextProviderTrait.php
+++ b/src/Context/ContextProviderTrait.php
@@ -31,7 +31,7 @@ trait ContextProviderTrait {
    * @see \Drupal\rules\Context\ContextProviderInterface
    */
   public function setProvidedValue($name, $value) {
-    $this->getProvidedContext($name)->setContextValue($value);
+    $this->providedContext[$name] = new Context($this->getProvidedContextDefinition($name), $value);
     return $this;
   }
 

--- a/src/Engine/RulesState.php
+++ b/src/Engine/RulesState.php
@@ -10,6 +10,7 @@ namespace Drupal\rules\Engine;
 use Drupal\Component\Utility\SafeMarkup;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Plugin\Context\ContextInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\Core\TypedData\DataReferenceInterface;
 use Drupal\Core\TypedData\ListInterface;
@@ -95,7 +96,15 @@ class RulesState implements RulesStateInterface {
     $context = $this->getVariable($parts[0]);
     $typed_data = $context->getContextData();
     if (count($parts) == 1) {
-      return $typed_data;
+      if ($typed_data instanceof TypedDataInterface) {
+        return $typed_data;
+      }
+      else {
+        $definition = \Drupal::typedDataManager()->createDataDefinition('any');
+        $wrapped_data = \Drupal::typedDataManager()->create($definition);
+        $wrapped_data->setValue($typed_data);
+        return $wrapped_data;
+      }
     }
     $current_selector = $parts[0];
     foreach (explode(':', $parts[1]) as $name) {


### PR DESCRIPTION
…) from Rules.

This is a first pass; Kernel tests setting NULL contexts still fail.

Issue https://www.drupal.org/node/2575977
