### PR TITLE
Issue #2592891: Updating the execute() and evaluate() functions in Ru…

### DIFF
--- a/src/Core/RulesActionBase.php
+++ b/src/Core/RulesActionBase.php
@@ -99,7 +99,9 @@ abstract class RulesActionBase extends ContextAwarePluginBase implements RulesAc
     // passing the defined context as arguments.
     $args = [];
     foreach ($this->getContexts() as $name => $context) {
-      $args[$name] = $context->getContextValue();
+      if ($context->hasContextValue()) {
+        $args[$name] = $context->getContextValue();
+      }
     }
     call_user_func_array([$this, 'doExecute'], $args);
   }

--- a/src/Core/RulesConditionBase.php
+++ b/src/Core/RulesConditionBase.php
@@ -43,7 +43,9 @@ abstract class RulesConditionBase extends ConditionPluginBase implements RulesCo
     // passing the defined context as arguments.
     $args = [];
     foreach ($this->getContextDefinitions() as $name => $definition) {
-      $args[$name] = $this->getContextValue($name);
+      if (!is_null($this->getContextValue($name))) {
+        $args[$name] = $this->getContextValue($name);
+      }
     }
     return call_user_func_array([$this, 'doEvaluate'], $args);
   }

--- a/src/Plugin/RulesAction/SystemMessage.php
+++ b/src/Plugin/RulesAction/SystemMessage.php
@@ -46,7 +46,7 @@ class SystemMessage extends RulesActionBase {
    * @param bool $repeat
    *   (optional) TRUE if the message should be repeated.
    */
-  protected function doExecute($message, $type, $repeat) {
+  protected function doExecute($message, $type, $repeat = FALSE) {
     // @todo Should we do the sanitization somewhere else? D7 had the sanitize
     // flag in the context definition.
     $message = SafeMarkup::checkPlain($message);


### PR DESCRIPTION
…lesActionBase and RulesConditionBase to not add NULL values for contexts that do not exist; fixing a test that did not provide a default for a non-required value.

See d.o issue https://www.drupal.org/node/2593891

Also: execute() and evaluate() are using different methods to get the context values for the array. Is this right? Or should I update them to be the same. And if I should update them, which one should I update? I'm not sure which one is more efficient or what.
