### PR TITLE
Issue #2610458: Squelch annotation objects.

### DIFF
--- a/src/Context/Annotation/ContextDefinition.php
+++ b/src/Context/Annotation/ContextDefinition.php
@@ -8,6 +8,7 @@
 namespace Drupal\rules\Context\Annotation;
 
 use Drupal\Core\Annotation\ContextDefinition as CoreContextDefinition;
+use Drupal\Core\Annotation\Translation;
 use Drupal\rules\Context\ContextDefinition as RulesContextDefinition;
 
 /**
@@ -33,6 +34,12 @@ class ContextDefinition extends CoreContextDefinition {
    * {@inheritdoc}
    */
   public function __construct(array $values) {
+    // Filter out any @Translation annotation objects.
+    foreach ($values as $key => $value) {
+      if ($value instanceof Translation) {
+        $values[$key] = $value->get();
+      }
+    }
     $this->definition = RulesContextDefinition::createFromArray($values);
   }
 
@@ -40,6 +47,7 @@ class ContextDefinition extends CoreContextDefinition {
    * Returns the value of an annotation.
    *
    * @return \Drupal\rules\Context\ContextDefinitionInterface.
+   *   Return the Rules version of the ContextDefinitionInterface.
    */
   public function get() {
     return $this->definition;


### PR DESCRIPTION
Drupal Issue https://www.drupal.org/node/2610458.

<del>I have a test for this, but it makes sense to integrate it into the test class created for #2591177
(Rules context processing coerces most context types to 'any').</del>

Includes a test.
