### PR TITLE
Remove usage of deprecated !placeholder

### DIFF
--- a/rules.module
+++ b/rules.module
@@ -19,9 +19,9 @@ use Drupal\rules\Event\UserLogoutEvent;
 function rules_help($route_name, RouteMatchInterface $route_match) {
   switch ($route_name) {
     case 'entity.rules_reaction_rule.collection':
-      $output = t('Reaction rules, listed below, react on selected events on the site. Each reaction rule may fire any number of <em>actions</em>, and may have any number of <em>conditions</em> that must be met for the actions to be executed. You can also set up <a href="!url1">components</a> – stand-alone sets of Rules configuration that can be used in Rules and other parts of your site. See <a href="!url2">the online documentation</a> for an introduction on how to use Rules.', [
-        '!url1' => \Drupal::url('entity.rules_component.collection'),
-        '!url2' => 'http://drupal.org/node/298480',
+      $output = t('Reaction rules, listed below, react on selected events on the site. Each reaction rule may fire any number of <em>actions</em>, and may have any number of <em>conditions</em> that must be met for the actions to be executed. You can also set up <a href=":url1">components</a> – stand-alone sets of Rules configuration that can be used in Rules and other parts of your site. See <a href=":url2">the online documentation</a> for an introduction on how to use Rules.', [
+        ':url1' => \Drupal::url('entity.rules_component.collection'),
+        ':url2' => 'http://drupal.org/node/298480',
       ]);
       return $output;
   }


### PR DESCRIPTION
!placeholder is deprecated and using it in hook_help generates a user error:
<img width="1358" alt="before" src="https://cloud.githubusercontent.com/assets/4950254/11404795/199dfb2e-93a4-11e5-9ba8-1cee9a60432b.png">

We can use :placeholder instead for URLs. In manual testing this patch gets rid of the error and the HTML is still correct:

<img width="1295" alt="after" src="https://cloud.githubusercontent.com/assets/4950254/11404793/186ff054-93a4-11e5-9471-6ea955b4bab8.png">
