### PR TITLE
Added composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "drupal/rules",
+  "description": "The Rules module allows site administrators to define conditionally executed actions based on occurring events.",
+  "type": "drupal-module",
+  "license": "GPL-2.0+",
+  "minimum-stability": "dev",
+  "require": { }
+}


### PR DESCRIPTION
I would love to be able to add the Rules module to my D8 projects using composer. Adding the composer.json file to the project root allows that, even during development.

For reference, the Redirect module is doing it here: https://github.com/md-systems/redirect
