### PR TITLE
Issue #2650426 by fago: Convert placeholder separater from : to . for…

### DIFF
--- a/src/TypedData/PlaceholderResolver.php
+++ b/src/TypedData/PlaceholderResolver.php
@@ -108,7 +108,7 @@ class PlaceholderResolver implements PlaceholderResolverInterface {
   /**
    * Parses the main placeholder part.
    *
-   * Main placeholder parts look like 'property:property|filter(arg)|filter'.
+   * Main placeholder parts look like 'property.property|filter(arg)|filter'.
    *
    * @param string $main_part
    *   The main placeholder part.
@@ -129,7 +129,7 @@ class PlaceholderResolver implements PlaceholderResolverInterface {
     if (!$main_part) {
       return [[], []];
     }
-    $properties = explode(':', $main_part);
+    $properties = explode('.', $main_part);
     $last_part = array_pop($properties);
     $filter_expressions = array_filter(explode('|', $last_part));
     // If there is a property, the first part, before the first |, is it.
@@ -178,13 +178,13 @@ class PlaceholderResolver implements PlaceholderResolverInterface {
    * {@inheritdoc}
    */
   public function scan($text) {
-    // Matches tokens with the following pattern: {{ $name:$property_path }}
+    // Matches tokens with the following pattern: {{ $name.$property_path }}
     // $name and $property_path may not contain {{ }} characters.
     // $name may not contain : or whitespace characters, but $property_path may.
     preg_match_all('/
       \{\{             # {{ - pattern start
-      ([^\{\}:|]+)      # match $type not containing whitespace : { or }
-      ((:|\|)          # : - separator
+      ([^\{\}.|]+)      # match $type not containing whitespace . { or }
+      ((.|\|)          # . - separator
       ([^\{\}]+))?     # match $name not containing { or }
       \}\}             # }} - pattern end
       /x', $text, $matches);
@@ -195,11 +195,11 @@ class PlaceholderResolver implements PlaceholderResolverInterface {
     // Iterate through the matches, building an associative array containing
     // $tokens grouped by $types, pointing to the version of the token found in
     // the source text. For example,
-    // $results['node']['title'] = '[node:title]';.
+    // $results['node']['title'] = '[node.title]';.
     $results = [];
     for ($i = 0; $i < count($tokens); $i++) {
-      // Remove leading whitespaces and ":", but not the | denoting a filter.
-      $main_part = trim($tokens[$i], ": \t\n\r\0\x0B");
+      // Remove leading whitespaces and ".", but not the | denoting a filter.
+      $main_part = trim($tokens[$i], ". \t\n\r\0\x0B");
       $results[trim($names[$i])][$main_part] = $matches[0][$i];
     }
 

--- a/src/TypedData/PlaceholderResolverInterface.php
+++ b/src/TypedData/PlaceholderResolverInterface.php
@@ -14,6 +14,14 @@ use Drupal\Core\Render\BubbleableMetadata;
  *
  * This is a Typed Data based alternative to the token service, see
  * \Drupal\Core\Utility\Token.
+ *
+ * Placeholder tokens use the format {{ data.property.property|filter1 }},
+ * while filters may be piped and can have arguments; e.g.,
+ * {{ data | filter1 | filter2('argument1', 'argument') }}
+ *
+ * The name of the filter refers to the filter plugin ID. The arguments which
+ * are allowed or even required depend on the filter plugin, see
+ * \Drupal\rules\TypedData\DataFilterInterface.
  */
 interface PlaceholderResolverInterface {
 
@@ -97,8 +105,8 @@ interface PlaceholderResolverInterface {
    *   name. For each data name, the value is another associative array
    *   containing the completed, discovered placeholder and the main placeholder
    *   part as key; i.e. the placeholder without brackets and data name. For
-   *   example, for the placeholder [data:property:property|filter] the
-   *   main placeholder part is 'property:property|filter'.
+   *   example, for the placeholder {{ data.property.property|filter }} the
+   *   main placeholder part is 'property.property|filter'.
    */
   public function scan($text);
 

--- a/tests/src/Kernel/CoreIntegrationTest.php
+++ b/tests/src/Kernel/CoreIntegrationTest.php
@@ -155,7 +155,7 @@ class CoreIntegrationTest extends RulesDrupalTestBase {
       ->addContextDefinition('message', ContextDefinition::create('string'))
       ->addContextDefinition('type', ContextDefinition::create('string'))
       ->setContextValue('node', $node)
-      ->setContextValue('message', 'Hello {{ node:uid:entity:name:value }}!')
+      ->setContextValue('message', 'Hello {{ node.uid.entity.name.value }}!')
       ->setContextValue('type', 'status')
       ->execute();
 
@@ -198,7 +198,7 @@ class CoreIntegrationTest extends RulesDrupalTestBase {
       ->addContextDefinition('message', ContextDefinition::create('string'))
       ->addContextDefinition('type', ContextDefinition::create('string'))
       ->setContextValue('node', $node)
-      ->setContextValue('message', "The node was created in the year {{ node:created:value | format_date('custom', 'Y') }}")
+      ->setContextValue('message', "The node was created in the year {{ node.created.value | format_date('custom', 'Y') }}")
       ->setContextValue('type', 'status')
       ->execute();
 

--- a/tests/src/Kernel/TypedData/PlaceholderResolverTest.php
+++ b/tests/src/Kernel/TypedData/PlaceholderResolverTest.php
@@ -106,14 +106,14 @@ class PlaceholderResolverTest extends KernelTestBase {
    * @cover scan
    */
   public function testScanningForPlaceholders() {
-    $text = 'token {{example:foo}} and {{example:foo:bar}} just as {{example:foo|default(bar)}} and {{ example:whitespace }}';
+    $text = 'token {{example.foo}} and {{example.foo.bar}} just as {{example.foo|default(bar)}} and {{ example.whitespace }}';
     $placeholders = $this->placeholderResolver->scan($text);
     $this->assertEquals([
       'example' => [
-        'foo' => '{{example:foo}}',
-        'foo:bar' => '{{example:foo:bar}}',
-        'foo|default(bar)' => '{{example:foo|default(bar)}}',
-        'whitespace' => '{{ example:whitespace }}',
+        'foo' => '{{example.foo}}',
+        'foo.bar' => '{{example.foo.bar}}',
+        'foo|default(bar)' => '{{example.foo|default(bar)}}',
+        'whitespace' => '{{ example.whitespace }}',
       ],
     ], $placeholders);
     // Test a simple placeholder with filters only.
@@ -130,11 +130,11 @@ class PlaceholderResolverTest extends KernelTestBase {
    * @cover resolvePlaceholders
    */
   public function testResolvingPlaceholders() {
-    $text = 'test {{node:title}} and {{node:title:value}}';
+    $text = 'test {{node.title}} and {{node.title.value}}';
     $result = $this->placeholderResolver->resolvePlaceholders($text, ['node' => $this->node->getTypedData()]);
     $expected = [
-      '{{node:title}}' => 'test',
-      '{{node:title:value}}' => 'test',
+      '{{node.title}}' => 'test',
+      '{{node.title.value}}' => 'test',
     ];
     $this->assertEquals($expected, $result);
 
@@ -155,7 +155,7 @@ class PlaceholderResolverTest extends KernelTestBase {
    * @cover replacePlaceHolders
    */
   public function testReplacePlaceholders() {
-    $text = 'test {{node:title}} and {{node:title:value}}';
+    $text = 'test {{node.title}} and {{node.title.value}}';
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test test and test', $result);
   }
@@ -170,7 +170,7 @@ class PlaceholderResolverTest extends KernelTestBase {
         'type' => 'user',
       ]);
     $this->node->uid->entity = $user;
-    $text = 'test {{node:title}} and {{node:uid:entity:name}}';
+    $text = 'test {{node.title}} and {{node.uid.entity.name}}';
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test test and test', $result);
   }
@@ -179,11 +179,11 @@ class PlaceholderResolverTest extends KernelTestBase {
    * @cover replacePlaceHolders
    */
   public function testPlaceholdersWithMissingData() {
-    $text = 'test {{node:title:1:value}}';
+    $text = 'test {{node.title.1.value}}';
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()], NULL, []);
-    $this->assertEquals('test {{node:title:1:value}}', $result);
+    $this->assertEquals('test {{node.title.1.value}}', $result);
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()], NULL, ['clear' => FALSE]);
-    $this->assertEquals('test {{node:title:1:value}}', $result);
+    $this->assertEquals('test {{node.title.1.value}}', $result);
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()], NULL, ['clear' => TRUE]);
     $this->assertEquals('test ', $result);
   }
@@ -193,7 +193,7 @@ class PlaceholderResolverTest extends KernelTestBase {
    */
   public function testStringEncoding() {
     $this->node->title->value = '<b>XSS</b>';
-    $text = 'test {{node:title}}';
+    $text = 'test {{node.title}}';
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test ' . new HtmlEscapedText('<b>XSS</b>'), $result);
   }
@@ -203,7 +203,7 @@ class PlaceholderResolverTest extends KernelTestBase {
    */
   public function testIntegerPlaceholder() {
     $this->node->field_integer->value = 3;
-    $text = 'test {{node:field_integer:0:value}}';
+    $text = 'test {{node.field_integer.0.value}}';
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test 3', $result);
   }
@@ -213,7 +213,7 @@ class PlaceholderResolverTest extends KernelTestBase {
    */
   public function testListPlaceholder() {
     $this->node->field_integer = [1, 2];
-    $text = 'test {{node:field_integer}}';
+    $text = 'test {{node.field_integer}}';
     $result = $this->placeholderResolver->replacePlaceHolders($text, ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test 1, 2', $result);
   }
@@ -224,13 +224,13 @@ class PlaceholderResolverTest extends KernelTestBase {
   public function testApplyingFilters() {
     $this->node->field_integer = [1, 2, NULL];
     $this->node->title->value = NULL;
-    $result = $this->placeholderResolver->replacePlaceHolders("test {{node:field_integer:2:value|default('0')}}", ['node' => $this->node->getTypedData()]);
+    $result = $this->placeholderResolver->replacePlaceHolders("test {{node.field_integer.2.value|default('0')}}", ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test 0', $result);
-    $result = $this->placeholderResolver->replacePlaceHolders("test {{node:title:value|default('tEsT')|lower}}", ['node' => $this->node->getTypedData()]);
+    $result = $this->placeholderResolver->replacePlaceHolders("test {{node.title.value|default('tEsT')|lower}}", ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test test', $result);
 
     // Test filter expressions with whitespaces.
-    $result = $this->placeholderResolver->replacePlaceHolders("test {{ node:title:value | default('tEsT') | lower }}", ['node' => $this->node->getTypedData()]);
+    $result = $this->placeholderResolver->replacePlaceHolders("test {{ node.title.value | default('tEsT') | lower }}", ['node' => $this->node->getTypedData()]);
     $this->assertEquals('test test', $result);
 
     // Test a filter expression on data without accessing a property.
@@ -256,13 +256,13 @@ class PlaceholderResolverTest extends KernelTestBase {
     $bubbleable_metadata = new BubbleableMetadata();
     // Save the node, so it gets a cache tag.
     $this->node->save();
-    $this->placeholderResolver->replacePlaceHolders('test {{node:field_integer}}', ['node' => $this->node->getTypedData()], $bubbleable_metadata);
+    $this->placeholderResolver->replacePlaceHolders('test {{node.field_integer}}', ['node' => $this->node->getTypedData()], $bubbleable_metadata);
     $expected = ['node:' . $this->node->id()];
     $this->assertEquals($expected, $bubbleable_metadata->getCacheTags());
 
     // Ensure cache tags of filters are added in.
     $bubbleable_metadata = new BubbleableMetadata();
-    $this->placeholderResolver->replacePlaceHolders("test {{ node:created:value | format_date('medium') }}", ['node' => $this->node->getTypedData()], $bubbleable_metadata);
+    $this->placeholderResolver->replacePlaceHolders("test {{ node.created.value | format_date('medium') }}", ['node' => $this->node->getTypedData()], $bubbleable_metadata);
     $expected = Cache::mergeTags(['node:' . $this->node->id()], DateFormat::load('medium')->getCacheTags());
     $this->assertEquals($expected, $bubbleable_metadata->getCacheTags());
   }


### PR DESCRIPTION
… compatibility with Twig syntax.
