### PR TITLE
Rebuild the container when a reaction rule is saved

### DIFF
--- a/src/Form/ReactionRuleEditForm.php
+++ b/src/Form/ReactionRuleEditForm.php
@@ -55,11 +55,11 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
    * @param \Drupal\rules\Engine\RulesEventManager $event_manager
    *   The event plugin manager.
    */
-  public function __construct(RulesEventManager $event_manager, EventDispatcherInterface $eventDispatcher, EventSubscriberInterface $genericEventSubscriber, DrupalKernelInterface $drupalKernel) {
+  public function __construct(RulesEventManager $event_manager, EventDispatcherInterface $event_dispatcher, EventSubscriberInterface $generic_event_subscriber, DrupalKernelInterface $drupal_kernel) {
     $this->eventManager = $event_manager;
-    $this->eventDispatcher = $eventDispatcher;
-    $this->genericEventSubscriber = $genericEventSubscriber;
-    $this->drupalKernel = $drupalKernel;
+    $this->eventDispatcher = $event_dispatcher;
+    $this->genericEventSubscriber = $generic_event_subscriber;
+    $this->drupalKernel = $drupal_kernel;
   }
 
   /**

--- a/src/Form/ReactionRuleEditForm.php
+++ b/src/Form/ReactionRuleEditForm.php
@@ -7,9 +7,12 @@
 
 namespace Drupal\rules\Form;
 
+use Drupal\Core\DrupalKernelInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\rules\Engine\RulesEventManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Provides a form to edit a reaction rule.
@@ -26,20 +29,49 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
   protected $eventManager;
 
   /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface.
+   */
+  protected $eventDispatcher;
+
+  /**
+   * The generic event subscriber.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventSubscriberInterface
+   */
+  protected $genericEventSubscriber;
+
+  /**
+   * The Drupal kernel.
+   *
+   * @var \Drupal\Core\DrupalKernelInterface.
+   */
+  protected $drupalKernel;
+
+  /**
    * Constructs a new object of this class.
    *
    * @param \Drupal\rules\Engine\RulesEventManager $event_manager
    *   The event plugin manager.
    */
-  public function __construct(RulesEventManager $event_manager) {
+  public function __construct(RulesEventManager $event_manager, EventDispatcherInterface $eventDispatcher, EventSubscriberInterface $genericEventSubscriber, DrupalKernelInterface $drupalKernel) {
     $this->eventManager = $event_manager;
+    $this->eventDispatcher = $eventDispatcher;
+    $this->genericEventSubscriber = $genericEventSubscriber;
+    $this->drupalKernel = $drupalKernel;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static($container->get('plugin.manager.rules_event'));
+    return new static(
+      $container->get('plugin.manager.rules_event'),
+      $container->get('event_dispatcher'),
+      $container->get('rules.event_subscriber'),
+      $container->get('kernel')
+    );
   }
 
   /**
@@ -76,6 +108,14 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
     // Also remove the temporarily stored rule, it has been persisted now.
     $this->deleteFromTempStore();
 
+    // After the reaction rule is saved, we need to rebuild the container,
+    // otherwise the reaction rule will not fire. However, we can do an
+    // optimization: if our generic event subscriber is already registered to
+    // the event in the kernel/container then we don't need to rebuild.
+    if (!$this->isRuleEventRegistered()) {
+      $this->drupalKernel->rebuildContainer();
+    }
+
     drupal_set_message($this->t('Reaction rule %label has been updated.', ['%label' => $this->entity->label()]));
   }
 
@@ -93,6 +133,31 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
    */
   protected function getRuleConfig() {
     return $this->entity;
+  }
+
+  /**
+   * Checks if the event of the current rule is registered into the container.
+   *
+   * @return true | false
+   */
+  protected function isRuleEventRegistered() {
+    // To check if the event of the rule is registered, we have to check if the
+    // generic subscriber is registered for the event. In order to check if the
+    // generic subscriber is already registered for the event, we have to search
+    // in the listeners list for an object with the same class as our generic
+    // event subscriber which is registered for that event.
+    $event_name = $this->getRuleConfig()->getEvent();
+    $listeners = $this->eventDispatcher->getListeners();
+    $event_is_registered  = FALSE;
+    if (!empty($listeners[$event_name])) {
+      $generic_subscriber_class = get_class($this->genericEventSubscriber);
+      foreach ($listeners[$event_name] as $listener) {
+        if (is_object($listener[0]) && get_class($listener[0]) == $generic_subscriber_class) {
+          $event_is_registered = TRUE;
+        }
+      }
+    }
+    return $event_is_registered;
   }
 
 }

--- a/src/Form/ReactionRuleEditForm.php
+++ b/src/Form/ReactionRuleEditForm.php
@@ -138,7 +138,8 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
   /**
    * Checks if the event of the current rule is registered into the container.
    *
-   * @return true | false
+   * @return bool
+   *   TRUE if the event is registered, FALSE otherwise.
    */
   protected function isRuleEventRegistered() {
     // To check if the event of the rule is registered, we have to check if the

--- a/src/Form/ReactionRuleEditForm.php
+++ b/src/Form/ReactionRuleEditForm.php
@@ -149,16 +149,15 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
     // event subscriber which is registered for that event.
     $event_name = $this->getRuleConfig()->getEvent();
     $listeners = $this->eventDispatcher->getListeners();
-    $event_is_registered  = FALSE;
     if (!empty($listeners[$event_name])) {
       $generic_subscriber_class = get_class($this->genericEventSubscriber);
       foreach ($listeners[$event_name] as $listener) {
         if (is_object($listener[0]) && get_class($listener[0]) == $generic_subscriber_class) {
-          $event_is_registered = TRUE;
+          return TRUE;
         }
       }
     }
-    return $event_is_registered;
+    return FALSE;
   }
 
 }

--- a/tests/src/Functional/ConfigureAndExecuteTest.php
+++ b/tests/src/Functional/ConfigureAndExecuteTest.php
@@ -91,10 +91,6 @@ class ConfigureAndExecuteTest extends RulesBrowserTestBase {
     // One more save to permanently store the rule.
     $this->pressButton('Save');
 
-    // Rebuild the container so that the new Rules event is picked up.
-    $this->drupalGet('admin/config/development/performance');
-    $this->pressButton('Clear all caches');
-
     // Add a node now and check if our rule triggers.
     $this->drupalGet('node/add/article');
     $this->fillField('Title', 'Test title');


### PR DESCRIPTION
Rebuild the container when a reaction rule is saved and the generic subscriber is not already registered for the event of the rule.

d.o issue: https://www.drupal.org/node/2648284
