### PR TITLE
Rebuild the container in the ReactionRuleStorage on update / delete and remove the rebuildContainer call from the tests.

### DIFF
--- a/src/Form/ReactionRuleEditForm.php
+++ b/src/Form/ReactionRuleEditForm.php
@@ -7,12 +7,9 @@
 
 namespace Drupal\rules\Form;
 
-use Drupal\Core\DrupalKernelInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\rules\Engine\RulesEventManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Provides a form to edit a reaction rule.
@@ -29,49 +26,20 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
   protected $eventManager;
 
   /**
-   * The event dispatcher.
-   *
-   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface.
-   */
-  protected $eventDispatcher;
-
-  /**
-   * The generic event subscriber.
-   *
-   * @var \Symfony\Component\EventDispatcher\EventSubscriberInterface
-   */
-  protected $genericEventSubscriber;
-
-  /**
-   * The Drupal kernel.
-   *
-   * @var \Drupal\Core\DrupalKernelInterface.
-   */
-  protected $drupalKernel;
-
-  /**
    * Constructs a new object of this class.
    *
    * @param \Drupal\rules\Engine\RulesEventManager $event_manager
    *   The event plugin manager.
    */
-  public function __construct(RulesEventManager $event_manager, EventDispatcherInterface $event_dispatcher, EventSubscriberInterface $generic_event_subscriber, DrupalKernelInterface $drupal_kernel) {
+  public function __construct(RulesEventManager $event_manager) {
     $this->eventManager = $event_manager;
-    $this->eventDispatcher = $event_dispatcher;
-    $this->genericEventSubscriber = $generic_event_subscriber;
-    $this->drupalKernel = $drupal_kernel;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.rules_event'),
-      $container->get('event_dispatcher'),
-      $container->get('rules.event_subscriber'),
-      $container->get('kernel')
-    );
+    return new static($container->get('plugin.manager.rules_event'));
   }
 
   /**
@@ -113,14 +81,6 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
     // Also remove the temporarily stored rule, it has been persisted now.
     $this->deleteFromTempStore();
 
-    // After the reaction rule is saved, we need to rebuild the container,
-    // otherwise the reaction rule will not fire. However, we can do an
-    // optimization: if our generic event subscriber is already registered to
-    // the event in the kernel/container then we don't need to rebuild.
-    if (!$this->isRuleEventRegistered()) {
-      $this->drupalKernel->rebuildContainer();
-    }
-
     drupal_set_message($this->t('Reaction rule %label has been updated.', ['%label' => $this->entity->label()]));
   }
 
@@ -147,31 +107,6 @@ class ReactionRuleEditForm extends RulesComponentFormBase {
    */
   protected function getRuleConfig() {
     return $this->entity;
-  }
-
-  /**
-   * Checks if the event of the current rule is registered into the container.
-   *
-   * @return bool
-   *   TRUE if the event is registered, FALSE otherwise.
-   */
-  protected function isRuleEventRegistered() {
-    // To check if the event of the rule is registered, we have to check if the
-    // generic subscriber is registered for the event. In order to check if the
-    // generic subscriber is already registered for the event, we have to search
-    // in the listeners list for an object with the same class as our generic
-    // event subscriber which is registered for that event.
-    $event_name = $this->getRuleConfig()->getEvent();
-    $listeners = $this->eventDispatcher->getListeners();
-    if (!empty($listeners[$event_name])) {
-      $generic_subscriber_class = get_class($this->genericEventSubscriber);
-      foreach ($listeners[$event_name] as $listener) {
-        if (is_object($listener[0]) && get_class($listener[0]) == $generic_subscriber_class) {
-          return TRUE;
-        }
-      }
-    }
-    return FALSE;
   }
 
 }

--- a/tests/src/Kernel/EventIntegrationTest.php
+++ b/tests/src/Kernel/EventIntegrationTest.php
@@ -59,8 +59,6 @@ class EventIntegrationTest extends RulesDrupalTestBase {
     ]);
     $config_entity->save();
 
-    // Rebuild the container so that the newly configured event gets picked up.
-    $this->container->get('kernel')->rebuildContainer();
     // The logger instance has changed, refresh it.
     $this->logger = $this->container->get('logger.channel.rules');
 
@@ -88,8 +86,6 @@ class EventIntegrationTest extends RulesDrupalTestBase {
     ]);
     $config_entity->save();
 
-    // Rebuild the container so that the newly configured event gets picked up.
-    $this->container->get('kernel')->rebuildContainer();
     // The logger instance has changed, refresh it.
     $this->logger = $this->container->get('logger.channel.rules');
 
@@ -117,8 +113,6 @@ class EventIntegrationTest extends RulesDrupalTestBase {
     ]);
     $config_entity->save();
 
-    // Rebuild the container so that the newly configured event gets picked up.
-    $this->container->get('kernel')->rebuildContainer();
     // The logger instance has changed, refresh it.
     $this->logger = $this->container->get('logger.channel.rules');
 
@@ -145,8 +139,6 @@ class EventIntegrationTest extends RulesDrupalTestBase {
     ]);
     $config_entity->save();
 
-    // Rebuild the container so that the newly configured event gets picked up.
-    $this->container->get('kernel')->rebuildContainer();
     // The logger instance has changed, refresh it.
     $this->logger = $this->container->get('logger.channel.rules');
 
@@ -174,8 +166,6 @@ class EventIntegrationTest extends RulesDrupalTestBase {
     ]);
     $config_entity->save();
 
-    // Rebuild the container so that the newly configured event gets picked up.
-    $this->container->get('kernel')->rebuildContainer();
     // The logger instance has changed, refresh it.
     $this->logger = $this->container->get('logger.channel.rules');
 


### PR DESCRIPTION
Three main things this patch does:
- moves the code that rebuilds the container from the Rule edit from into the ReactionRuleStorage class
- removes the calls to rebuildContainer() from the tests.
- rebuilds the container when needed also when a rule is deleted.

Issue on d.o: https://www.drupal.org/node/2659990
