### PR TITLE
Issue #2661362: @file block for kernel tests incorrect namespace updated..

### DIFF
--- a/tests/src/Kernel/ConfigEntityDefaultsTest.php
+++ b/tests/src/Kernel/ConfigEntityDefaultsTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\ConfigEntityDefaultsTest.
+ * Contains \Drupal\Tests\rules\Kernel\ConfigEntityDefaultsTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/ConfigEntityTest.php
+++ b/tests/src/Kernel/ConfigEntityTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\ConfigEntityTest.
+ * Contains \Drupal\Tests\rules\Kernel\ConfigEntityTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/ContextIntegrationTest.php
+++ b/tests/src/Kernel/ContextIntegrationTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\ContextIntegrationTest.
+ * Contains \Drupal\Tests\rules\Kernel\ContextIntegrationTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/CoreIntegrationTest.php
+++ b/tests/src/Kernel/CoreIntegrationTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\CoreIntegrationTest.
+ * Contains \Drupal\Tests\rules\Kernel\CoreIntegrationTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/DataProcessorTest.php
+++ b/tests/src/Kernel/DataProcessorTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\DataProcessorTest.
+ * Contains \Drupal\Tests\rules\Kernel\DataProcessorTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/EntityViewTest.php
+++ b/tests/src/Kernel/EntityViewTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\EntityViewTest.
+ * Contains \Drupal\Tests\rules\Kernel\EntityViewTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/EventIntegrationTest.php
+++ b/tests/src/Kernel/EventIntegrationTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\EventIntegrationTest.
+ * Contains \Drupal\Tests\rules\Kernel\EventIntegrationTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/RedirectEventSubscriberTest.php
+++ b/tests/src/Kernel/RedirectEventSubscriberTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\ConfigEntityDefaultsTest.
+ * Contains \Drupal\Tests\rules\Kernel\ConfigEntityDefaultsTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/RulesDrupalTestBase.php
+++ b/tests/src/Kernel/RulesDrupalTestBase.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\RulesDrupalTestBase.
+ * Contains \Drupal\Tests\rules\Kernel\RulesDrupalTestBase.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/RulesEngineTest.php
+++ b/tests/src/Kernel/RulesEngineTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\RulesEngineTest.
+ * Contains \Drupal\Tests\rules\Kernel\RulesEngineTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;

--- a/tests/src/Kernel/TokenIntegrationTest.php
+++ b/tests/src/Kernel/TokenIntegrationTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains \Drupal\rules\Tests\TokenIntegrationTest.
+ * Contains \Drupal\Tests\rules\Kernel\TokenIntegrationTest.
  */
 
 namespace Drupal\Tests\rules\Kernel;


### PR DESCRIPTION
see: https://www.drupal.org/node/2661362
