### PR TITLE
Issue #2702127 by yanniboi: Active / Inactive toggle for rules

### DIFF
--- a/rules.routing.yml
+++ b/rules.routing.yml
@@ -56,6 +56,7 @@ entity.rules_reaction_rule.enable:
     op: 'enable'
   requirements:
     _permission: 'administer rules+administer rules reactions'
+    _csrf_token: 'TRUE'
 
 entity.rules_reaction_rule.disable:
   path: '/admin/config/workflow/rules/reactions/disable/{rules_reaction_rule}'
@@ -64,6 +65,7 @@ entity.rules_reaction_rule.disable:
     op: 'disable'
   requirements:
     _permission: 'administer rules+administer rules reactions'
+    _csrf_token: 'TRUE'
 
 ### Rules Components
 entity.rules_component.collection:

--- a/rules.routing.yml
+++ b/rules.routing.yml
@@ -49,6 +49,22 @@ entity.rules_reaction_rule.delete_form:
   requirements:
     _permission: 'administer rules+administer rules reactions'
 
+entity.rules_reaction_rule.enable:
+  path: '/admin/config/workflow/rules/reactions/enable/{rules_reaction_rule}'
+  defaults:
+    _controller: '\Drupal\rules\Controller\RulesReactionController::performReactionRuleOperation'
+    op: 'enable'
+  requirements:
+    _permission: 'administer rules+administer rules reactions'
+
+entity.rules_reaction_rule.disable:
+  path: '/admin/config/workflow/rules/reactions/disable/{rules_reaction_rule}'
+  defaults:
+    _controller: '\Drupal\rules\Controller\RulesReactionController::performReactionRuleOperation'
+    op: 'disable'
+  requirements:
+    _permission: 'administer rules+administer rules reactions'
+
 ### Rules Components
 entity.rules_component.collection:
   path: '/admin/config/workflow/rules/components'

--- a/src/Controller/RulesReactionController.php
+++ b/src/Controller/RulesReactionController.php
@@ -1,15 +1,9 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\rules\Controller\RulesReactionController.
- */
-
 namespace Drupal\rules\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
-
 
 /**
  * Provides route controllers for Reaction Rules.

--- a/src/Controller/RulesReactionController.php
+++ b/src/Controller/RulesReactionController.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\rules\Controller\RulesReactionController.
+ */
+
+namespace Drupal\rules\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+
+
+/**
+ * Provides route controllers for Reaction Rules.
+ */
+class RulesReactionController extends ControllerBase {
+
+  /**
+   * Enables or disables a Rule.
+   *
+   * @param \Drupal\Core\Config\Entity\ConfigEntityInterface $rules_reaction_rule
+   *   The rule entity.
+   * @param string $op
+   *   The operation to perform, usually 'enable' or 'disable'.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   A redirect back to the rules list page.
+   */
+  public function performReactionRuleOperation(ConfigEntityInterface $rules_reaction_rule, $op) {
+    $rules_reaction_rule->$op()->save();
+
+    if ($op == 'enable') {
+      drupal_set_message($this->t('The %label rule has been enabled.', ['%label' => $rules_reaction_rule->label()]));
+    }
+    elseif ($op == 'disable') {
+      drupal_set_message($this->t('The %label rule has been disabled.', ['%label' => $rules_reaction_rule->label()]));
+    }
+
+    return $this->redirect('entity.rules_reaction_rule.collection');
+  }
+
+}

--- a/src/Entity/ReactionRuleConfig.php
+++ b/src/Entity/ReactionRuleConfig.php
@@ -43,6 +43,8 @@ use Drupal\rules\Engine\RulesComponent;
  *     "collection" = "/admin/config/workflow/rules",
  *     "edit-form" = "/admin/config/workflow/rules/reactions/edit/{rules_reaction_rule}",
  *     "delete-form" = "/admin/config/workflow/rules/reactions/delete/{rules_reaction_rule}",
+ *     "enable" = "/admin/config/workflow/rules/reactions/enable/{rules_reaction_rule}",
+ *     "disable" = "/admin/config/workflow/rules/reactions/disable/{rules_reaction_rule}",
  *     "break-lock-form" = "/admin/config/workflow/rules/reactions/edit/break-lock/{rules_reaction_rule}"
  *   }
  * )

--- a/src/EventSubscriber/GenericEventSubscriber.php
+++ b/src/EventSubscriber/GenericEventSubscriber.php
@@ -119,8 +119,10 @@ class GenericEventSubscriber implements EventSubscriberInterface {
     // variables added by one rule are not interfering with the variables of
     // another rule.
     foreach ($triggered_events as $triggered_event) {
-      // @todo Only load active reaction rules here.
-      $configs = $storage->loadByProperties(['events.*.event_name' => $triggered_event]);
+      $configs = $storage->loadByProperties([
+        'events.*.event_name' => $triggered_event,
+        'status' => 1,
+      ]);
 
       // Loop over all rules and execute them.
       foreach ($configs as $config) {

--- a/src/Form/RulesComponentFormBase.php
+++ b/src/Form/RulesComponentFormBase.php
@@ -82,6 +82,12 @@ abstract class RulesComponentFormBase extends EntityForm {
       '#title' => $this->t('Description'),
     ];
 
+    $form['settings']['status'] = [
+      '#type' => 'checkbox',
+      '#default_value' => $this->entity->status(),
+      '#title' => $this->t('Active'),
+    ];
+
     return parent::form($form, $form_state);
   }
 

--- a/tests/src/Functional/ConfigureAndExecuteTest.php
+++ b/tests/src/Functional/ConfigureAndExecuteTest.php
@@ -92,6 +92,16 @@ class ConfigureAndExecuteTest extends RulesBrowserTestBase {
     $this->pressButton('Save');
 
     $this->assertSession()->pageTextContains('Title matched "Test title"!');
+
+    // Disable rule and make sure it doesn't get triggered.
+    $this->drupalGet('admin/config/workflow/rules');
+    $this->clickLink('Disable');
+
+    $this->drupalGet('node/add/article');
+    $this->fillField('Title', 'Test title');
+    $this->pressButton('Save');
+
+    $this->assertSession()->pageTextNotContains('Title matched "Test title"!');
   }
 
 }

--- a/tests/src/Functional/UiPageTest.php
+++ b/tests/src/Functional/UiPageTest.php
@@ -96,6 +96,23 @@ class UiPageTest extends RulesBrowserTestBase {
   }
 
   /**
+   * Tests that enabling and disabling a rule works.
+   */
+  public function testRuleStatusOperations() {
+    // Setup an active rule.
+    $this->testCreateReactionRule();
+    $this->drupalGet('admin/config/workflow/rules');
+
+    // Test disabling.
+    $this->clickLink('Disable');
+    $this->assertSession()->pageTextContains('The Test rule rule has been disabled.');
+
+    // Test enabling.
+    $this->clickLink('Enable');
+    $this->assertSession()->pageTextContains('The Test rule rule has been enabled.');
+  }
+
+  /**
    * Tests that deleting an expression from a rule works.
    */
   public function testDeleteExpressionInRule() {


### PR DESCRIPTION
This issue is mirrored on d.o by https://www.drupal.org/node/2702127.

I have exposed the config entity operations for enable and disable by adding link templates and added a Controller to handle them.

I have also added the 'active' checkbox to reaction rule settings and made sure that the event subscriber only triggers active rules.
