### PR TITLE
Update ExpressionSerializationTest.php

### DIFF
--- a/tests/src/Integration/Engine/ExpressionSerializationTest.php
+++ b/tests/src/Integration/Engine/ExpressionSerializationTest.php
@@ -8,6 +8,8 @@ use Drupal\Tests\rules\Integration\RulesIntegrationTestBase;
 
 /**
  * Tests serializing expression objects.
+ *
+ * @group rules
  */
 class ExpressionSerializationTest extends RulesIntegrationTestBase {
 


### PR DESCRIPTION
In order for Simpletest to run these integration tests every class needs an @group. This is the only test class missing one.
