### PR TITLE
Issue #2755415 by neerajsingh: Remove @file tag docblock

### DIFF
--- a/tests/src/Unit/RulesConditionContainerTest.php
+++ b/tests/src/Unit/RulesConditionContainerTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\Tests\rules\Unit\RulesConditionContainerTest.
- */
-
 namespace Drupal\Tests\rules\Unit;
 
 use Drupal\rules\Engine\ConditionExpressionContainer;


### PR DESCRIPTION
As per coding standard documentation at 'https://www.drupal.org/coding-standards/docs', @file tag docblock should not be there in the files that contain a namespaced class/interface/trait, whose file name is the class name with a .php extension.
