### PR TITLE
Added action plugin: Fetch entities by view

### DIFF
--- a/src/Plugin/RulesAction/EntityFetchByView.php
+++ b/src/Plugin/RulesAction/EntityFetchByView.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\rules\Plugin\RulesAction;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\rules\Core\RulesActionBase;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a generic 'Fetch entities by view' action.
+ *
+ * @RulesAction(
+ *   id = "rules_entity_fetch_by_view",
+ *   deriver = "Drupal\rules\Plugin\RulesAction\EntityFetchByViewDeriver",
+ *   category = @Translation("Entity")
+ * )
+ */
+class EntityFetchByView extends RulesActionBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $viewStorage;
+
+  /**
+   * Constructs an EntityFetchByView object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->viewStorage = $entity_type_manager->getStorage('view');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    $view = $this->viewStorage->load($this->pluginDefinition['view_id'])->getExecutable();
+    $arguments = [];
+
+    foreach ($this->getContexts() as $name => $context) {
+      $data = $context->getContextData()->getValue();
+      $arguments[$name] = $data instanceof EntityInterface ? $data->id() : $data;
+    }
+
+    $view->setDisplay($this->pluginDefinition['display_id']);
+
+    $real_args = array_map(function ($key) use ($arguments) {
+      return $arguments[$key];
+    }, array_keys($view->display_handler->getOption('arguments')));
+
+    $view->setArguments($real_args);
+
+    $entities = $view->render($this->pluginDefinition['display_id']);
+    $this->setProvidedValue('entity_fetched', $entities ? $entities : []);
+  }
+}

--- a/src/Plugin/RulesAction/EntityFetchByViewDeriver.php
+++ b/src/Plugin/RulesAction/EntityFetchByViewDeriver.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Drupal\rules\Plugin\RulesAction;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\rules\Context\ContextDefinition;
+use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Derives EntityFetchByView plugin definitions from views configurations.
+ *
+ * @see EntityFetchByView
+ */
+class EntityFetchByViewDeriver extends DeriverBase implements ContainerDeriverInterface  {
+  use StringTranslationTrait;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $viewsStorage;
+
+  /**
+   * Array mapping table names to entity types.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeInterface[]
+   */
+  protected $entityTables = [];
+
+  /**
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   * @param string $base_plugin_id
+   * @return static
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('string_translation')
+    );
+  }
+
+  /**
+   * EntityFetchByViewDeriver constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, TranslationInterface $string_translation) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->viewsStorage = $entity_type_manager->getStorage('view');
+    $this->stringTranslation = $string_translation;
+
+    // Build an array of table names pointing to corresponding entity types.
+    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
+
+      if ($base_table = $entity_type->getBaseTable()) {
+        $this->entityTables[$base_table] = $entity_type;
+      }
+
+      if ($data_table = $entity_type->getDataTable()) {
+        $this->entityTables[$data_table] = $entity_type;
+      }
+
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+    foreach (Views::getApplicableViews('rules') as $data) {
+      list($view_id, $display_id) = $data;
+      $view = $this->viewsStorage->load($view_id);
+      $table = $view->get('base_table');
+      if (isset($this->entityTables[$table])) {
+        $entity_type = $this->entityTables[$table];
+
+        $context = [];
+
+        /** @var $views_executable \Drupal\views\ViewExecutable */
+        $views_executable = $view->getExecutable();
+        $views_executable->setDisplay($display_id);
+        $display = $views_executable->getDisplay();
+
+        foreach ($display->getOption('arguments') as $argument_name => $argument) {
+          $label = $argument['admin_label'] ? $argument['admin_label'] : $argument_name;
+          $required = !in_array($argument['default_action'], ['ignore', 'default']);
+          $type = strpos($argument['validate']['type'], 'entity:') !== FALSE ? "entity:" . explode(':', $argument['validate']['type'])[1] : "string";
+
+          $context[$argument_name] = ContextDefinition::create($type)
+            ->setLabel($label)
+            ->setRequired($required);
+        }
+
+        $this->derivatives[$view_id . ':' . $display_id]= [
+            'label' => $this->t('Fetch entities from @view - @display', [
+              '@view' => $view_id,
+              '@display' => $display->display['display_title'],
+            ]),
+            'view_id' => $view_id,
+            'display_id' => $display_id,
+            'context' => $context,
+            'provides' => [
+              'entity_fetched' => ContextDefinition::create("entity:" . $entity_type->id())
+                ->setLabel($entity_type->getLabel())
+                ->setMultiple(TRUE)
+            ],
+          ] + $base_plugin_definition;
+      }
+    }
+    return $this->derivatives;
+  }
+}

--- a/src/Plugin/RulesAction/EntityFetchByViewDeriver.php
+++ b/src/Plugin/RulesAction/EntityFetchByViewDeriver.php
@@ -8,6 +8,7 @@ use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\rules\Context\ContextDefinition;
+use Drupal\rules\Plugin\views\display\Rules;
 use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -58,63 +59,61 @@ class EntityFetchByViewDeriver extends DeriverBase implements ContainerDeriverIn
     $this->entityTypeManager = $entity_type_manager;
     $this->viewsStorage = $entity_type_manager->getStorage('view');
     $this->stringTranslation = $string_translation;
-
-    // Build an array of table names pointing to corresponding entity types.
-    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
-
-      if ($base_table = $entity_type->getBaseTable()) {
-        $this->entityTables[$base_table] = $entity_type;
-      }
-
-      if ($data_table = $entity_type->getDataTable()) {
-        $this->entityTables[$data_table] = $entity_type;
-      }
-
-    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function getDerivativeDefinitions($base_plugin_definition) {
+
+    // Build a lookup dictionary of table names pointing to corresponding
+    // entity types. Used to determine which entity type is the result of a
+    // given view.
+    $entity_types = [];
+    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
+      if ($base_table = $entity_type->getBaseTable()) {
+        $entity_types[$base_table] = $entity_type;
+      }
+
+      if ($data_table = $entity_type->getDataTable()) {
+        $entity_types[$data_table] = $entity_type;
+      }
+    }
+
     foreach (Views::getApplicableViews('rules') as $data) {
       list($view_id, $display_id) = $data;
+
+      // Fetch the current view applicable view and get it's base table.
+      /** @var $view \Drupal\views\Entity\View */
       $view = $this->viewsStorage->load($view_id);
       $table = $view->get('base_table');
-      if (isset($this->entityTables[$table])) {
-        $entity_type = $this->entityTables[$table];
 
-        $context = [];
-
-        /** @var $views_executable \Drupal\views\ViewExecutable */
+      /** @var $entity_type \Drupal\Core\Entity\EntityTypeInterface */
+      if ($entity_type = $entity_types[$table] ?: FALSE) {
+        // Proceed only, if the view is based on an entity.
+        // Prepare views executable and display.
         $views_executable = $view->getExecutable();
         $views_executable->setDisplay($display_id);
         $display = $views_executable->getDisplay();
 
-        foreach ($display->getOption('arguments') as $argument_name => $argument) {
-          $label = $argument['admin_label'] ? $argument['admin_label'] : $argument_name;
-          $required = !in_array($argument['default_action'], ['ignore', 'default']);
-          $type = strpos($argument['validate']['type'], 'entity:') !== FALSE ? "entity:" . explode(':', $argument['validate']['type'])[1] : "string";
-
-          $context[$argument_name] = ContextDefinition::create($type)
-            ->setLabel($label)
-            ->setRequired($required);
-        }
-
-        $this->derivatives[$view_id . ':' . $display_id]= [
-            'label' => $this->t('Fetch entities from @view - @display', [
-              '@view' => $view_id,
-              '@display' => $display->display['display_title'],
-            ]),
-            'view_id' => $view_id,
-            'display_id' => $display_id,
-            'context' => $context,
-            'provides' => [
-              'entity_fetched' => ContextDefinition::create("entity:" . $entity_type->id())
-                ->setLabel($entity_type->getLabel())
-                ->setMultiple(TRUE)
-            ],
+        // Build the list of derivative definitions if the display is of type
+        // "Rules".
+        if ($display instanceof Rules) {
+          $this->derivatives[$view_id . ':' . $display_id]= [
+              'label' => $this->t('Fetch entities from @view - @display', [
+                '@view' => $view_id,
+                '@display' => $display->display['display_title'],
+              ]),
+              'view_id' => $view_id,
+              'display_id' => $display_id,
+              'context' => $display->getRulesContext(),
+              'provides' => [
+                'entity_fetched' => ContextDefinition::create("entity:" . $entity_type->id())
+                  ->setLabel($entity_type->getLabel())
+                  ->setMultiple(TRUE)
+              ],
           ] + $base_plugin_definition;
+        }
       }
     }
     return $this->derivatives;

--- a/src/Plugin/views/display/Rules.php
+++ b/src/Plugin/views/display/Rules.php
@@ -1,0 +1,108 @@
+<?php
+namespace Drupal\rules\Plugin\views\display;
+
+use Drupal\views\Annotation\ViewsDisplay;
+use Drupal\views\Plugin\views\display\DisplayPluginBase;
+
+/**
+ * @ViewsDisplay(
+ *   id = "rules",
+ *   title = @Translation("Rules"),
+ *   admin = @Translation("Rules entity source"),
+ *   help = @Translation("Provide views results to rules workflows."),
+ *   theme = "views_view",
+ *   register_theme = FALSE,
+ *   uses_menu_links = FALSE,
+ *   rules = TRUE
+ * )
+ */
+class Rules extends DisplayPluginBase {
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesAJAX = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesPager = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesAttachments = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesAreas = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesMore = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesOptions = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defineOptions() {
+    $options = parent::defineOptions();
+
+    // Force the style plugin to 'entity_reference_style' and the row plugin to
+    // 'fields'.
+    $options['style']['contains']['type'] = array('default' => 'rules');
+    $options['defaults']['default']['style'] = FALSE;
+
+    // Set the display title to an empty string (not used in this display type).
+    $options['title']['default'] = '';
+    $options['defaults']['default']['title'] = FALSE;
+
+    return $options;
+  }
+
+  /**
+   * Overrides \Drupal\views\Plugin\views\display\DisplayPluginBase::optionsSummary().
+   *
+   * Disable 'cache' and 'title' so it won't be changed.
+   */
+  public function optionsSummary(&$categories, &$options) {
+    parent::optionsSummary($categories, $options);
+    unset($options['title']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getType() {
+    return 'rules';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    return $this->view->render($this->display['id']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    if (!empty($this->view->result) && $this->view->style_plugin->evenEmpty()) {
+      return $this->view->style_plugin->render($this->view->result);
+    }
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function usesExposed() {
+    return FALSE;
+  }
+}

--- a/src/Plugin/views/style/Rules.php
+++ b/src/Plugin/views/style/Rules.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\Rules\Plugin\views\style;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\views\Plugin\views\style\StylePluginBase;
+use Drupal\views\ResultRow;
+
+/**
+ * @ViewsStyle(
+ *   id = "rules",
+ *   title = @Translation("Rules entity listing"),
+ *   help = @Translation("Returns a list of entities as result"),
+ *   theme = "views_view_unformatted",
+ *   register_theme = FALSE,
+ *   display_types = {"rules"}
+*  )
+ */
+class Rules extends StylePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesRowPlugin = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesFields = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesGrouping = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesRowClass = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesOptions = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+
+    $entities = array_map(function (ResultRow $row) {
+      return $row->_entity;
+    }, $this->view->result);
+    
+    $entities = array_filter($entities, function ($value) { return (bool) $value; });
+    
+    if (!empty($this->view->live_preview)) {
+      return [
+        '#theme' => 'item_list',
+        '#items' => array_map(function (EntityInterface $entity) {
+          return $entity->label();
+        }, $entities)
+      ];
+    }
+
+    return $entities;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evenEmpty() {
+    return TRUE;
+  }
+}


### PR DESCRIPTION
I've added a plugin that enables rules to fetch lists of entities from view. Similar to the action available in [Rules bonus pack](https://www.drupal.org/project/rb), but with typed contexts.

There is a views display plugin to be used for views that act as rules data sources. A plugin deriver will provide a rules action for every views display using this plugin, and add views contexts based on the views  argument definitions.

I'm aware that there is no test coverage and probably some bugs. I would like to discuss feasibility of this approach before going any further.
