### PR TITLE
Issue #2849779: Drupal 8.3 Critical - Implement missing PluginDefinitionInterface methods in RulesUiDefinition.

### DIFF
--- a/src/Ui/RulesUiDefinition.php
+++ b/src/Ui/RulesUiDefinition.php
@@ -111,6 +111,20 @@ class RulesUiDefinition implements PluginDefinitionInterface {
   /**
    * {@inheritdoc}
    */
+  public function id() {
+    return $this->id;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getProvider() {
+    return $this->provider;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function setClass($class) {
     $this->class = $class;
     return $this;


### PR DESCRIPTION
Rules on Drupal 8.3.0 breaks completely, this PR comes directly from d.o.
Ref. https://www.drupal.org/node/2849779