### PR TITLE
Fix order of arguments in "contains" comparison

### DIFF
--- a/src/Plugin/Condition/DataComparison.php
+++ b/src/Plugin/Condition/DataComparison.php
@@ -61,7 +61,7 @@ class DataComparison extends RulesConditionBase {
         return $data > $value;
 
       case 'contains':
-        return is_string($data) && strpos($data, $value) !== FALSE || is_array($data) && in_array($value, $data);
+        return is_string($data) && strpos($value, $data) !== FALSE || is_array($data) && in_array($data, $value);
 
       case 'in':
         return is_array($value) && in_array($data, $value);


### PR DESCRIPTION
I believe the order of arguments in the "contains" branch of the doEvaluate() method are backwards. This swaps them around.